### PR TITLE
Moved predict_mask functions into happy_transformer and cleaned them up.

### DIFF
--- a/happy_transformer/happy_bert.py
+++ b/happy_transformer/happy_bert.py
@@ -1,9 +1,7 @@
 # disable pylint TODO warning
 # pylint: disable=W0511
 
-import torch
 from transformers import BertForMaskedLM, BertTokenizer
-import numpy as np
 
 from happy_transformer.happy_transformer import HappyTransformer
 
@@ -21,60 +19,3 @@ class HappyBERT(HappyTransformer):
         self.model = 'BERT'
 
         self.transformer.eval()
-
-    def predict_mask(self, text: str):
-        """
-        :param text: a string with a masked token within it
-        :return: predicts the most likely word to fill the mask and its score
-        """
-
-        # TODO: put in HappyBERT. Overwrite HappyTransformer.
-        # TODO: easy: create a method to check if the sentence is valid
-        # TODO: easy: if the sentence is not valid, provide the user with input requirements
-        # TODO: easy: if sentence is not valid, indicate where the user messed up
-
-        # TODO: medium: make it more modular
-
-        tokens_tensor, segments_tensors, masked_index =\
-            self._HappyTransformer__get_tensors_and_mask_idx(text)
-
-        with torch.no_grad():
-            outputs = self.transformer(tokens_tensor, token_type_ids=segments_tensors)
-            predictions = outputs[0]
-
-            softmax = self._HappyTransformer__softmax(predictions)
-
-            top_prediction = torch.topk(softmax[0, masked_index], 1)
-            prediction_softmax = top_prediction[0].tolist()
-            prediction_index = top_prediction[1].tolist()
-
-            prediction_token = self.tokenizer.convert_ids_to_tokens(prediction_index)
-
-           # TODO: easy: del various variables
-
-            if self.gpu_support == "cuda":
-                torch.cuda.empty_cache()
-
-            return prediction_token[0], prediction_softmax[0]
-
-    def predict_mask_with_options(self, text: str, options: list):
-
-        tokens_tensor, segments_tensors, masked_index =\
-            self._HappyTransformer__get_tensors_and_mask_idx(text)
-
-        with torch.no_grad():
-            outputs = self.transformer(tokens_tensor, token_type_ids=segments_tensors)
-            predictions = outputs[0]
-
-            softmax = self._HappyTransformer__softmax(predictions)[0]
-
-            option_ids = [self.tokenizer.encode(option) for option in options]
-
-            option_probs = list(map(lambda x: self.soft_sum(x, softmax, masked_index), option_ids))
-            tupled_option = tuple(zip(options, option_probs))
-            ranked_scores = sorted(tupled_option, key=lambda x: x[1], reverse=True)
-
-            if self.gpu_support == "cuda":
-                torch.cuda.empty_cache()
-            ranked_scores = self._HappyTransformer__format_option_scores(ranked_scores)
-            return ranked_scores

--- a/happy_transformer/happy_gpt2.py
+++ b/happy_transformer/happy_gpt2.py
@@ -1,7 +1,7 @@
 # pylint: disable=W0511
 from transformers import GPT2LMHeadModel, GPT2Tokenizer
+
 from happy_transformer.happy_transformer import HappyTransformer
-import torch
 
 
 class HappyGPT2(HappyTransformer):
@@ -13,96 +13,12 @@ class HappyGPT2(HappyTransformer):
         self.tokenizer = GPT2Tokenizer.from_pretrained(model)
         self.tokenizer.mask_token = '<mask>'
         self.masked_token = self.tokenizer.mask_token
-        # self.sep_token = self.tokenizer.sep_token
-        # self.cls_token = self.tokenizer._cls_token
+        self.sep_token = ''
+        self.cls_token = ''
 
         self.model = 'GPT2'
 
         self.transformer.eval()
 
-    def predict_mask(self, text: str):
-        """
-        :param text: a string with a masked token within it
-        :return: predicts the most likely word to fill the mask and its probability
-        """
-
-        formatted_text = self._HappyTransformer__get_formatted_text(text)
-        tokenized_text = self.tokenizer.tokenize(formatted_text)
-
-        masked_index = self._HappyTransformer__get_prediction_index(tokenized_text)
-        segments_ids = self.__get_segment_ids(tokenized_text)
-        indexed_tokens = self.tokenizer.convert_tokens_to_ids(tokenized_text)
-
-        # Convert inputs to PyTorch tensors
-        tokens_tensor = torch.tensor([indexed_tokens])
-        segments_tensors = torch.tensor([segments_ids])
-
-        tokens_tensor = tokens_tensor.to(self.gpu_support)
-        segments_tensors = segments_tensors.to(self.gpu_support)
-
-        with torch.no_grad():
-            outputs = self.transformer(tokens_tensor, token_type_ids=segments_tensors)
-            predictions = outputs[0]
-
-            softmax = self._HappyTransformer__softmax(predictions)
-
-            top_prediction = torch.topk(softmax[0, masked_index], 1)
-            prediction_softmax = top_prediction[0].tolist()
-            prediction_index = top_prediction[1].tolist()
-
-            prediction_token = self.tokenizer.convert_ids_to_tokens(prediction_index)
-
-            # TODO: easy: del various variables
-            del outputs, softmax, predictions, top_prediction, prediction_index
-
-            if self.gpu_support == "cuda":
-                torch.cuda.empty_cache()
-
-            return prediction_token, prediction_softmax
-
-    def predict_mask_with_options(self, text: str, options: list):
-        """
-        :param text: a string with a masked token within it
-        :param options: a list of strings as options for masked word
-        :return: predicts the most likely word from list of options
-        to fill the mask and its probability
-        """
-
-        # formatted_text = self._HappyTransformer__get_formatted_text(text)
-        tokenized_text = self.tokenizer.tokenize(text)
-
-        masked_index = self.__get_prediction_index(tokenized_text)
-        segments_ids = self.__get_segment_ids(tokenized_text)
-        indexed_tokens = self.tokenizer.convert_tokens_to_ids(tokenized_text)
-
-        # Convert inputs to PyTorch tensors
-        tokens_tensor = torch.tensor([indexed_tokens])
-        segments_tensors = torch.tensor([segments_ids])
-
-        tokens_tensor = tokens_tensor.to(self.gpu_support)
-        segments_tensors = segments_tensors.to(self.gpu_support)
-
-        with torch.no_grad():
-            outputs = self.transformer(tokens_tensor)
-            predictions = outputs[0]
-
-            softmax = self._HappyTransformer__softmax(predictions)[0]
-
-            option_ids = [self.tokenizer.encode(option) for option in options]
-
-            option_probs = list(map(lambda x: self.soft_sum(x, softmax, masked_index), option_ids))
-            tupled_option = tuple(zip(options, option_probs))
-            ranked_scores = sorted(tupled_option, key=lambda x: x[1], reverse=True)
-
-            if self.gpu_support == "cuda":
-                torch.cuda.empty_cache()
-            del outputs, softmax, predictions
-
-            ranked_scores = self._HappyTransformer__format_option_scores(ranked_scores)
-            return ranked_scores
-
-    def __get_segment_ids(self, tokenized_text):
+    def _get_segment_ids(self, tokenized_text):
         return [0] * len(tokenized_text)
-
-    def __get_prediction_index(self, tokenized_text):
-        return tokenized_text.index('<mask>')

--- a/happy_transformer/happy_transformer.py
+++ b/happy_transformer/happy_transformer.py
@@ -18,9 +18,9 @@ class HappyTransformer:
     Initializes pytroch's transformer models and provided methods for
     their basic functionality.
 
-    Philosophy: Automatically make decisions for the user so that they don't have to
-                have any understanding of PyTorch or transformer models to be able
-                to utilize their capabilities.
+    Philosophy: Automatically make decisions for the user so that they don't
+                have to have any understanding of PyTorch or transformer
+                models to be able to utilize their capabilities.
     """
 
     def __init__(self):
@@ -111,7 +111,6 @@ class HappyTransformer:
                 else:
                     new_text.append(self.sep_token)
                 # must be a middle punctuation
-
         new_text.append(self.sep_token)
         text = " ".join(new_text).replace('[MASK]', self.masked_token)
         text = self.tokenizer.tokenize(text)
@@ -128,7 +127,7 @@ class HappyTransformer:
         :return: a tensor of the softmaxes of the predictions of the
                  transformer
         """
-        segments_ids = self.__get_segment_ids(text)
+        segments_ids = self._get_segment_ids(text)
         indexed_tokens = self.tokenizer.convert_tokens_to_ids(text)
 
         # Convert inputs to PyTorch tensors
@@ -167,7 +166,7 @@ class HappyTransformer:
         # TODO: make it an external function
         return value.exp() / (value.exp().sum(-1)).unsqueeze(-1)
 
-    def __get_segment_ids(self, tokenized_text: list):
+    def _get_segment_ids(self, tokenized_text: list):
         """
         Converts a list of tokens into segment_ids. The segment id is a array
         representation of the location for each character in the
@@ -175,7 +174,8 @@ class HappyTransformer:
 
         Example:
         tokenized_text = ['[CLS]', 'who', 'was', 'jim', 'henson', '?', '[SEP]',
-                         'jim', '[MASK]', 'was', 'a', 'puppet', '##eer', '[SEP]']
+                          'jim', '[MASK]', 'was', 'a', 'puppet', '##eer',
+                          '[SEP]']
         segments_ids = [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1]
         returns segments_ids
         """
@@ -189,11 +189,12 @@ class HappyTransformer:
             # add exception case for XLNet
         return segment_ids
 
-    def finish_sentence(self, text: str, maxPredictionLength = 100):
+    def finish_sentence(self, text: str, maxPredictionLength=100):
         """
 
         :param text: a string that is the start of a sentence to be finished
-        :param maxPredictionLength: an int with the maximum number of words to be predicted
+        :param maxPredictionLength: an int with the maximum number of words to
+                                    be predicted
         :return: the completed sentence
         """
         father_predict = ""
@@ -203,7 +204,8 @@ class HappyTransformer:
             predict_text = text + self.masked_token
             predict_word = self.predict_mask(predict_text)[0]
 
-            if predict_word == father_predict and predict_word == grand_father_predict:
+            if predict_word == father_predict\
+                    and predict_word == grand_father_predict:
                 # if the same token was predicted three times in a row
                 return text
 

--- a/happy_transformer/happy_xlm.py
+++ b/happy_transformer/happy_xlm.py
@@ -1,5 +1,4 @@
 # pylint: disable=W0511
-import torch
 from transformers import XLMWithLMHeadModel, XLMTokenizer
 
 from happy_transformer.happy_transformer import HappyTransformer
@@ -18,91 +17,10 @@ class HappyXLM(HappyTransformer):
 
         self.transformer = XLMWithLMHeadModel.from_pretrained(model)
         self.tokenizer = XLMTokenizer.from_pretrained(model)
-        self.masked_token = self.tokenizer._mask_token
-        self.sep_token = self.tokenizer._sep_token
-        self.cls_token = self.tokenizer._cls_token
+        self.masked_token = self.tokenizer.mask_token
+        self.sep_token = self.tokenizer.sep_token
+        self.cls_token = self.tokenizer.cls_token
 
         self.model = 'XLM'
 
         self.transformer.eval()
-
-    def predict_mask(self, text: str):
-        """
-        :param text: a string with a masked token within it
-        :return: predicts the most likely word to fill the mask and its probability
-        """
-
-        formatted_text = self._HappyTransformer__get_formatted_text(text)
-        tokenized_text = self.tokenizer.tokenize(formatted_text)
-
-        masked_index = self._HappyTransformer__get_prediction_index(tokenized_text)
-        segments_ids = self.__get_segment_ids(tokenized_text)
-        indexed_tokens = self.tokenizer.convert_tokens_to_ids(tokenized_text)
-
-        # Convert inputs to PyTorch tensors
-        tokens_tensor = torch.tensor([indexed_tokens])
-        segments_tensors = torch.tensor([segments_ids])
-
-        tokens_tensor = tokens_tensor.to(self.gpu_support)
-        segments_tensors = segments_tensors.to(self.gpu_support)
-
-        with torch.no_grad():
-            outputs = self.transformer(tokens_tensor, token_type_ids=segments_tensors)
-            predictions = outputs[0]
-
-            softmax = self._HappyTransformer__softmax(predictions)
-
-            top_prediction = torch.topk(softmax[0, masked_index], 1)
-            prediction_softmax = top_prediction[0].tolist()
-            prediction_index = top_prediction[1].tolist()
-
-            prediction_token = self.tokenizer.convert_ids_to_tokens(prediction_index)
-
-            # TODO: easy: del various variables
-            del outputs, softmax, predictions, top_prediction, prediction_index
-
-            if self.gpu_support == "cuda":
-                torch.cuda.empty_cache()
-
-            return prediction_token, prediction_softmax
-
-    def predict_mask_with_options(self, text: str, options: list):
-        """
-        :param text: a string with a masked token within it
-        :param options: a list of strings as options for masked word
-        :return: predicts the most likely word from list of options
-        to fill the mask and its probability
-        """
-
-        formatted_text = self._HappyTransformer__get_formatted_text(text)
-        tokenized_text = self.tokenizer.tokenize(formatted_text)
-
-        masked_index = self._HappyTransformer__get_prediction_index(tokenized_text)
-        segments_ids = self._HappyTransformer__get_segment_ids(tokenized_text)
-        indexed_tokens = self.tokenizer.convert_tokens_to_ids(tokenized_text)
-
-        # Convert inputs to PyTorch tensors
-        tokens_tensor = torch.tensor([indexed_tokens])
-        segments_tensors = torch.tensor([segments_ids])
-
-        tokens_tensor = tokens_tensor.to(self.gpu_support)
-        segments_tensors = segments_tensors.to(self.gpu_support)
-
-        with torch.no_grad():
-            outputs = self.transformer(tokens_tensor)
-            predictions = outputs[0]
-
-            softmax = self._HappyTransformer__softmax(predictions)[0]
-
-            option_ids = [self.tokenizer.encode(option) for option in options]
-
-            option_probs = list(map(lambda x: self.soft_sum(x, softmax, masked_index), option_ids))
-            tupled_option = tuple(zip(options, option_probs))
-            ranked_scores = sorted(tupled_option, key=lambda x: x[1], reverse=True)
-
-            if self.gpu_support == "cuda":
-                torch.cuda.empty_cache()
-            del outputs, softmax, predictions
-
-            ranked_scores = self._HappyTransformer__format_option_scores(ranked_scores)
-            return ranked_scores

--- a/happy_transformer/happy_xlnet.py
+++ b/happy_transformer/happy_xlnet.py
@@ -1,9 +1,7 @@
 # pylint: disable=W0511
-import torch
-import numpy as np
 from transformers import XLNetLMHeadModel, XLNetTokenizer
 
-from happy_transformer import HappyTransformer
+from happy_transformer.happy_transformer import HappyTransformer
 
 
 class HappyXLNET(HappyTransformer):
@@ -16,109 +14,10 @@ class HappyXLNET(HappyTransformer):
 
         self.transformer = XLNetLMHeadModel.from_pretrained(model)
         self.tokenizer = XLNetTokenizer.from_pretrained(model)
-        self.masked_token = self.tokenizer._mask_token
-        self.sep_token = self.tokenizer._sep_token
-        self.cls_token = self.tokenizer._cls_token
+        self.masked_token = self.tokenizer.mask_token
+        self.sep_token = self.tokenizer.sep_token
+        self.cls_token = self.tokenizer.cls_token
 
         self.model = 'XLNET'
 
         self.transformer.eval()
-
-    def predict_mask(self, text: str):
-        """
-        :param text: a string with a masked token within it
-        :return: predicts the most likely word to fill the mask and its probability
-        """
-
-        formatted_text = self._HappyTransformer__get_formatted_text(text)
-        tokenized_text = self.tokenizer.tokenize(formatted_text)
-
-        masked_index = self._HappyTransformer__get_prediction_index(tokenized_text)
-        segments_ids = self.__get_segment_ids(tokenized_text)
-        indexed_tokens = self.tokenizer.convert_tokens_to_ids(tokenized_text)
-
-        # Convert inputs to PyTorch tensors
-        tokens_tensor = torch.tensor([indexed_tokens])
-        segments_tensors = torch.tensor([segments_ids])
-
-        tokens_tensor = tokens_tensor.to(self.gpu_support)
-        segments_tensors = segments_tensors.to(self.gpu_support)
-
-        with torch.no_grad():
-            outputs = self.transformer(tokens_tensor, token_type_ids=segments_tensors)
-            predictions = outputs[0]
-
-            softmax = self._HappyTransformer__softmax(predictions)
-
-            top_prediction = torch.topk(softmax[0, masked_index], 1)
-            prediction_softmax = top_prediction[0].tolist()
-            prediction_index = top_prediction[1].tolist()
-
-            prediction_token = self.tokenizer.convert_ids_to_tokens(prediction_index)
-
-            # TODO: easy: del various variables
-            del outputs, softmax, predictions, top_prediction, prediction_index
-
-            if self.gpu_support == "cuda":
-                torch.cuda.empty_cache()
-
-            return prediction_token, prediction_softmax
-
-    def predict_mask_with_options(self, text: str, options: list):
-        """
-
-        :param text: a string with a masked token within it
-        :param options: a list of strings as options for masked word
-        :return: predicts the most likely word from list of options
-        to fill the mask and its probability
-        """
-
-        formatted_text = self._HappyTransformer__get_formatted_text(text)
-        tokenized_text = self.tokenizer.tokenize(formatted_text)
-
-        masked_index = self._HappyTransformer__get_prediction_index(tokenized_text)
-        segments_ids = self._HappyTransformer__get_segment_ids(tokenized_text)
-        indexed_tokens = self.tokenizer.convert_tokens_to_ids(tokenized_text)
-
-        # Convert inputs to PyTorch tensors
-        tokens_tensor = torch.tensor([indexed_tokens])
-        segments_tensors = torch.tensor([segments_ids])
-
-        tokens_tensor = tokens_tensor.to(self.gpu_support)
-        segments_tensors = segments_tensors.to(self.gpu_support)
-
-        with torch.no_grad():
-            outputs = self.transformer(tokens_tensor, token_type_ids=segments_tensors)
-            predictions = outputs[0]
-
-            softmax = self._HappyTransformer__softmax(predictions)[0]
-
-            option_ids = [self.tokenizer.encode(option) for option in options]
-
-            option_probs = list(map(lambda x: self.soft_sum(x, softmax, masked_index), option_ids))
-            tupled_option = tuple(zip(options, option_probs))
-            prediction_token = sorted(tupled_option, key=lambda x: x[1], reverse=True)
-
-            if self.gpu_support == "cuda":
-                torch.cuda.empty_cache()
-
-            return prediction_token
-
-    def soft_sum(self, option: list, softed, mask_id: int):
-        # TODO: Better logic.
-        """
-        Adds the softmax of a single option
-        XLNET tokenizer sometimes splits words in to pieces.
-        Ex: The councilmen -> ['the', 'council', 'men']
-        Pretty sure that this is mathematically wrong
-
-
-        :param option: Id of tokens in one option
-        :param softed: softmax of the output
-        :param mask_id: Index of masked word
-        :return: float Tensor
-        """
-        # Collects the softmax of all tokens in list
-        options = [softed[mask_id][op] for op in option]
-        return np.sum(options)
-


### PR DESCRIPTION
Moved the functions and fixed up formatting issues. Merged predict_mask and predict_mask_with_options in order to completely remove duplication of code between the two functions. Also tried to merge helper functions for the predict_mask into resonable sub methods and group them together. Added a note for future that developers should be overloading this method if they are used in future transformers that do not need this style to predict a mask.