### PR TITLE
Add multiple QA outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ print(result) # prints: 0.999990701675415
 
 *Determine the answer to a given question using a body of supplied text.*
 
-
+##### Single Answer
 **HappyBERT** has a method called "answer_question" which is used for question answering tasks.
 The method takes the following arguments:
 
@@ -372,6 +372,41 @@ text = "Ernie is an orange Muppet character on the long running PBS and HBO chil
 result = happy_bert.answer_question(question, text)
 print(type(result)) # prints: <class 'str'>
 print(result) # prints: bert
+```
+
+##### Multiple Answers
+**HappyBERT** has a method called "answers_to_question" which is used to generate multiple answers for a single question
+
+    1. question: The question to be answered
+    2. text: The text containing the answer to the question
+    3. k: The number of answers that will be returned 
+
+The output is a list of named tuples in descending order according to their probability. 
+Each tuple contains two fields: text and softmax. 
+The text field contains the answer in the form of a string. 
+The softmax field contains the "probability" of the answer as a float between 0 and 1. 
+
+###### Example 1:
+```sh
+from happytransformer import HappyBERT
+#--------------------------------------#
+happy_bert = HappyBERT()
+question = "Who does Ernie live with?"
+text = "Ernie is an orange Muppet character on the long running PBS and HBO children's television show Sesame Street. He and his roommate Bert form the comic duo Bert and Ernie, one of the program's centerpieces, with Ernie acting the role of the naïve troublemaker and Bert the world weary foil."  # Source: https://en.wikipedia.org/wiki/Ernie_(Sesame_Street)
+result = happy_bert.answers_to_question(question, text, k=3)
+print(type(result)) # prints: <class 'list'>
+print(result) # prints: [QAAnswer(text='bert', probability=0.9916905164718628), QAAnswer(text='roommate bert', probability=0.004403269849717617), QAAnswer(text='his roommate bert', probability=0.0039062034338712692)]
+
+best_answer = result[0]
+second_best_answer = result[1]
+
+print(type(best_answer)) # prints: <class 'happytransformer.qa_util.QAAnswer'>
+print(best_answer) # prints: QAAnswer(text='bert', probability=0.9916905164718628)
+
+print(best_answer.text) # prints: bert
+print(best_answer.softmax) # prints: 0.9916905164718628
+print(best_answer[0]) # prints: bert
+print(best_answer[1]) # prints:  0.9916905164718628
 ```
 
 

--- a/happytransformer/happy_bert.py
+++ b/happytransformer/happy_bert.py
@@ -167,7 +167,7 @@ class HappyBERT(HappyTransformer):
     def _run_qa_model(self, input_ids):
         if self.qa is None:
             self._get_question_answering()
-        sep_id = self.tokenizer.encode(self.sep_token)[-1]
+        sep_id = self.tokenizer.sep_token_id
         before_after_ids = [
             0 if i <= input_ids.index(sep_id) else 1
             for i in range(len(input_ids))
@@ -179,6 +179,7 @@ class HappyBERT(HappyTransformer):
             )
 
     def answers_to_question(self, question, context, k=10):
+        # TODO: filter out [SEP] and [CLS]
         input_ids = self._tokenize_qa(question, context)
         qa_output = self._run_qa_model(input_ids)
         probabilities = qa_probabilities(

--- a/happytransformer/happy_bert.py
+++ b/happytransformer/happy_bert.py
@@ -18,24 +18,8 @@ import torch
 import numpy as np
 
 from happytransformer.happy_transformer import HappyTransformer
+from happytransformer.qa_util import qa_start_end_pairs
 from happytransformer.math import softmax
-
-_QaAnswerLogit = namedtuple('_QaAnswerLogit', [
-    'start_idx','end_idx', 'logit'
-])
-
-def _qa_start_end_pairs(start_logits, end_logits):
-    sorted_starts_tensors = torch.sort(start_logits)
-    sorted_ends_tensors = torch.sort(end_logits)
-
-    sorted_start_scores = sorted_starts_tensors.values.tolist()
-    sorted_start_indices = sorted_starts_tensors.indices.tolist()
-
-    sorted_end_scores = sorted_ends_tensors.values.tolist()
-    sorted_end_indices = sorted_ends_tensors.indices.tolist()
-
-    
-
 
 class HappyBERT(HappyTransformer):
     """
@@ -197,7 +181,7 @@ class HappyBERT(HappyTransformer):
     def answers_to_question(self, question, context):
         input_ids = self._tokenize_qa(question, context)
         qa_output = self._run_qa_model(input_ids)
-        pairs = _qa_start_end_pairs(qa_output.start_logits[0], qa_output.end_logits[0])
+        pairs = qa_start_end_pairs(qa_output.start_logits[0], qa_output.end_logits[0])
         pair_logits = torch.tensor([
             pair.logit
             for pair in pairs

--- a/happytransformer/happy_bert.py
+++ b/happytransformer/happy_bert.py
@@ -188,7 +188,7 @@ class HappyBERT(HappyTransformer):
                     # grab ids from start to end (inclusive) and decode to text
                     input_ids[token_offset+answer.start_idx : token_offset+answer.end_idx+1]
                 ),
-                probability=answer.probability
+                softmax=answer.probability
             )
             for answer in probabilities
         ]

--- a/happytransformer/happy_bert.py
+++ b/happytransformer/happy_bert.py
@@ -186,11 +186,11 @@ class HappyBERT(HappyTransformer):
             qa_output.end_logits[0],
             10
         )
-        all_tokens = self.tokenizer.convert_ids_to_tokens(input_ids)
+
         return [
             QaAnswer(
                 text=self.tokenizer.decode(
-                    all_tokens[answer.start_idx:answer.end_idx+1]
+                    input_ids[answer.start_idx:answer.end_idx+1]
                 ),
                 probability=answer.probability
             )

--- a/happytransformer/happy_bert.py
+++ b/happytransformer/happy_bert.py
@@ -18,7 +18,7 @@ import torch
 import numpy as np
 
 from happytransformer.happy_transformer import HappyTransformer
-from happytransformer.qa_util import qa_probabilities, QaAnswer
+from happytransformer.qa_util import qa_probabilities, QAAnswer
 
 class HappyBERT(HappyTransformer):
     """
@@ -183,7 +183,7 @@ class HappyBERT(HappyTransformer):
         token_offset = sep_id_index + 1
 
         return [
-            QaAnswer(
+            QAAnswer(
                 text=self.tokenizer.decode(
                     # grab ids from start to end (inclusive) and decode to text
                     input_ids[token_offset+answer.start_idx : token_offset+answer.end_idx+1]

--- a/happytransformer/happy_bert.py
+++ b/happytransformer/happy_bert.py
@@ -171,7 +171,11 @@ class HappyBERT(HappyTransformer):
         return answer
 
     def _tokenize_qa(self, question, context):
-        input_text = self.cls_token + " " + question + " " + self.sep_token + " " + context + " " + self.sep_token
+        input_text = ' '.join([
+            self.cls_token, question, 
+            self.sep_token,
+            context, self.sep_token
+        ])
         input_ids = self.tokenizer.encode(input_text)
         return input_ids
 
@@ -179,18 +183,15 @@ class HappyBERT(HappyTransformer):
         if self.qa is None:
             self._get_question_answering()
         sep_id = self.tokenizer.encode(self.sep_token)[-1]
-        before_after_ids_tensor = [
+        before_after_ids = [
             0 if i <= input_ids.index(sep_id) else 1
             for i in range(len(input_ids))
         ]
-        input_ids_tensor = torch.tensor([input_ids])
-        before_after_ids_tensor = torch.tensor([before_after_ids_tensor])
         with torch.no_grad():
             return self.qa(
-                input_ids=input_ids_tensor,
-                token_type_ids=before_after_ids_tensor
+                input_ids=torch.tensor([input_ids]),
+                token_type_ids=torch.tensor([before_after_ids])
             )
-
 
     def answers_to_question(self, question, context):
         input_ids = self._tokenize_qa(question, context)

--- a/happytransformer/happy_bert.py
+++ b/happytransformer/happy_bert.py
@@ -19,7 +19,6 @@ import numpy as np
 
 from happytransformer.happy_transformer import HappyTransformer
 from happytransformer.qa_util import qa_probabilities, QaAnswer
-from happytransformer.math import softmax
 
 class HappyBERT(HappyTransformer):
     """

--- a/happytransformer/happy_bert.py
+++ b/happytransformer/happy_bert.py
@@ -134,26 +134,7 @@ class HappyBERT(HappyTransformer):
         :param text: The text containing the answer to the question
         :return: The answer to the given question, as a string
         """
-        if self.qa is None:
-            self._get_question_answering()
-        input_text = self.cls_token + " " + question + " " + self.sep_token + " " + text + " " + self.sep_token
-        input_ids = self.tokenizer.encode(input_text)
-        sep_val = self.tokenizer.encode(self.sep_token)[-1]
-        token_type_ids = [0 if i <= input_ids.index(sep_val) else 1
-                          for i in range(len(input_ids))]
-        token_tensor = torch.tensor([input_ids])
-        segment_tensor = torch.tensor([token_type_ids])
-        with torch.no_grad():
-           scores=  self.qa(input_ids=token_tensor,
-                    token_type_ids=segment_tensor)
-           start_scores = scores[0]
-           end_scores = scores[1]
-        all_tokens = self.tokenizer.convert_ids_to_tokens(input_ids)
-        answer_list = all_tokens[torch.argmax(start_scores):
-                                 torch.argmax(end_scores)+1]
-        answer = self.tokenizer.convert_tokens_to_string(answer_list)
-        answer = answer.replace(' \' ', '\' ').replace('\' s ', '\'s ')
-        return answer
+        return self.answers_to_question(question, text, 1)[0].text
 
     def _tokenize_qa(self, question, context):
         input_text = ' '.join([

--- a/happytransformer/happy_bert.py
+++ b/happytransformer/happy_bert.py
@@ -25,16 +25,17 @@ _QaAnswerLogit = namedtuple('_QaAnswerLogit', [
 ])
 
 def _qa_start_end_pairs(start_logits, end_logits):
-    pairs = (
-        _QaAnswerLogit(
-            start_idx, end_idx, 
-            logit=start_logit+end_logit
-        ) 
-        for start_idx, start_logit in enumerate(start_logits)
-        for end_idx, end_logit in enumerate(end_logits)
-        if end_idx > start_idx
-    )
-    return sorted(pairs, key=lambda answer: answer.logit, reverse=True)
+    sorted_starts_tensors = torch.sort(start_logits)
+    sorted_ends_tensors = torch.sort(end_logits)
+
+    sorted_start_scores = sorted_starts_tensors.values.tolist()
+    sorted_start_indices = sorted_starts_tensors.indices.tolist()
+
+    sorted_end_scores = sorted_ends_tensors.values.tolist()
+    sorted_end_indices = sorted_ends_tensors.indices.tolist()
+
+    
+
 
 class HappyBERT(HappyTransformer):
     """

--- a/happytransformer/happy_bert.py
+++ b/happytransformer/happy_bert.py
@@ -178,13 +178,13 @@ class HappyBERT(HappyTransformer):
                 token_type_ids=torch.tensor([before_after_ids])
             )
 
-    def answers_to_question(self, question, context):
+    def answers_to_question(self, question, context, k=10):
         input_ids = self._tokenize_qa(question, context)
         qa_output = self._run_qa_model(input_ids)
         probabilities = qa_probabilities(
             qa_output.start_logits[0],
             qa_output.end_logits[0],
-            10
+            k
         )
 
         return [

--- a/happytransformer/happy_bert.py
+++ b/happytransformer/happy_bert.py
@@ -165,7 +165,7 @@ class HappyBERT(HappyTransformer):
                 token_type_ids=torch.tensor([before_after_ids])
             )
 
-    def answers_to_question(self, question, context, k=10):
+    def answers_to_question(self, question, context, k=3):
         input_ids = self._tokenize_qa(question, context)
         qa_output = self._run_qa_model(input_ids)
         sep_id_index = input_ids.index(self.tokenizer.sep_token_id)

--- a/happytransformer/math.py
+++ b/happytransformer/math.py
@@ -1,2 +1,0 @@
-def softmax(value):
-    return value.exp() / (value.exp().sum(-1)).unsqueeze(-1)

--- a/happytransformer/math.py
+++ b/happytransformer/math.py
@@ -1,0 +1,2 @@
+def softmax(value):
+    return value.exp() / (value.exp().sum(-1)).unsqueeze(-1)

--- a/happytransformer/qa_util.py
+++ b/happytransformer/qa_util.py
@@ -1,7 +1,11 @@
+"""
+Contains named tuples and functions used by questions answering methods
+"""
+
 from collections import namedtuple
 import torch
 
-SumPair = namedtuple('SumPair',['idx1', 'idx2', 'sum'])
+SumPair = namedtuple('SumPair', ['idx1', 'idx2', 'sum'])
 
 def biggest_sums(items_a, items_b):
     '''
@@ -33,18 +37,19 @@ def biggest_sums(items_a, items_b):
             a_index += 1
 
 QAAnswerLogit = namedtuple('QaAnswerLogit', [
-    'start_idx','end_idx', 'logit'
+    'start_idx', 'end_idx', 'logit'
 ])
 
 def qa_logits(start_logits, end_logits):
-    '''
+    """
     Compute the logits for top qa pairs
     :param start_logits: tensor from qa model output
     :param end_logits: tensor from qa model output
     :returns: generator of namedtuples of the form
     (start_idx, end_idx, logit), sorted in descending order
     by score
-    ''' 
+    """
+
     sorted_starts_tensors = torch.sort(start_logits, descending=True)
     sorted_ends_tensors = torch.sort(end_logits, descending=True)
     # start logits sorted in descending order INDEPENDENTLY
@@ -72,21 +77,24 @@ def qa_logits(start_logits, end_logits):
     )
     return legit_answers
 
+
 QAProbability = namedtuple('QaProbability', [
     'start_idx', 'end_idx', 'probability'
 ])
-QAAnswer = namedtuple('QaAnswer',[
+
+
+QAAnswer = namedtuple('QaAnswer', [
     'text', 'softmax'
 ])
 
 def qa_probabilities(start_logits, end_logits, k):
-    '''
+    """
     Computes the top k qa probabilities, in terms of indices.
     :param start_logits: tensor from qa model output
     :param end_logits: tensor from qa model output
     :param k: number of results to return
     :returns: list of namedtuples of the form (text,probability)
-    '''
+    """
     top_answers = [
         qa_logit
         for qa_logit, _ in zip(qa_logits(start_logits, end_logits), range(k))

--- a/happytransformer/qa_util.py
+++ b/happytransformer/qa_util.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+import torch
 
 SumPair = namedtuple('SumPair',['idx1', 'idx2', 'sum'])
 
@@ -27,3 +28,27 @@ def biggest_sums(items_a, items_b):
             b_index += 1
         else:
             a_index += 1
+
+QaAnswerLogit = namedtuple('_QaAnswerLogit', [
+    'start_idx','end_idx', 'logit'
+])
+
+def qa_start_end_pairs(start_logits, end_logits):
+    sorted_starts_tensors = torch.sort(start_logits)
+    sorted_ends_tensors = torch.sort(end_logits)
+
+    sorted_start_scores = sorted_starts_tensors.values.tolist()
+    sorted_start_indices = sorted_starts_tensors.indices.tolist()
+
+    sorted_end_scores = sorted_ends_tensors.values.tolist()
+    sorted_end_indices = sorted_ends_tensors.indices.tolist()
+
+    sum_pairs = biggest_sums(sorted_start_scores, sorted_end_scores)
+    return (
+        QaAnswerLogit(
+            start_idx=sorted_start_indices[sum_pair.idx1],
+            end_idx=sorted_end_indices[sum_pair.idx2],
+            logit=sum_pair.sum
+        )
+        for sum_pair in sum_pairs
+    )

--- a/happytransformer/qa_util.py
+++ b/happytransformer/qa_util.py
@@ -29,26 +29,63 @@ def biggest_sums(items_a, items_b):
         else:
             a_index += 1
 
-QaAnswerLogit = namedtuple('_QaAnswerLogit', [
+QaAnswerLogit = namedtuple('QaAnswerLogit', [
     'start_idx','end_idx', 'logit'
 ])
 
-def qa_start_end_pairs(start_logits, end_logits):
+def qa_logits(start_logits, end_logits):
     sorted_starts_tensors = torch.sort(start_logits)
     sorted_ends_tensors = torch.sort(end_logits)
-
+    # start logits sorted in descending order INDEPENDENTLY
     sorted_start_scores = sorted_starts_tensors.values.tolist()
     sorted_start_indices = sorted_starts_tensors.indices.tolist()
-
+    # end logits sorted in descending order INDEPENDENTLY
     sorted_end_scores = sorted_ends_tensors.values.tolist()
     sorted_end_indices = sorted_ends_tensors.indices.tolist()
-
-    sum_pairs = biggest_sums(sorted_start_scores, sorted_end_scores)
-    return (
+    # start logit + end logit pairs sorted in descending order 
+    # of their sum TOGETHER
+    all_answers = (
         QaAnswerLogit(
             start_idx=sorted_start_indices[sum_pair.idx1],
             end_idx=sorted_end_indices[sum_pair.idx2],
             logit=sum_pair.sum
         )
-        for sum_pair in sum_pairs
+        for sum_pair in 
+        biggest_sums(sorted_start_scores, sorted_end_scores)
     )
+    # filter for only answers which have end after start
+    legit_answers = (
+        answer
+        for answer in all_answers
+        if answer.end_idx > answer.start_idx
+    )
+    return legit_answers
+
+QaProbability = namedtuple('QaProbability', [
+    'start_idx', 'end_idx', 'probability'
+])
+QaAnswer = namedtuple('QaAnswer',[
+    'text', 'probability'
+])
+
+def qa_probabilities(start_logits, end_logits, k):
+    answer_logits_iterator = qa_logits(start_logits, end_logits)
+    top_answers = [
+        next(answer_logits_iterator)
+        for _ in range(k)
+    ]
+    logit_scores = torch.tensor([
+        answer.logit
+        for answer in top_answers
+    ])
+
+    probabilities = torch.nn.Softmax()(logit_scores).tolist()
+    # NOTE: throwing away indices. Do we care?
+    return [
+        QaProbability(
+            start_idx=answer.start_idx,
+            end_idx=answer.end_idx,
+            probability=probability
+        )
+        for answer, probability in zip(top_answers, probabilities)
+    ]

--- a/happytransformer/qa_util.py
+++ b/happytransformer/qa_util.py
@@ -69,10 +69,9 @@ QaAnswer = namedtuple('QaAnswer',[
 ])
 
 def qa_probabilities(start_logits, end_logits, k):
-    answer_logits_iterator = qa_logits(start_logits, end_logits)
     top_answers = [
-        next(answer_logits_iterator)
-        for _ in range(k)
+        qa_logit
+        for qa_logit, _ in zip(qa_logits(start_logits, end_logits), range(k))
     ]
     logit_scores = torch.tensor([
         answer.logit

--- a/happytransformer/qa_util.py
+++ b/happytransformer/qa_util.py
@@ -5,9 +5,12 @@ SumPair = namedtuple('SumPair',['idx1', 'idx2', 'sum'])
 
 def biggest_sums(items_a, items_b):
     '''
-    assumes items_a and items_b sorted (descending)
-    return (idx1,idx2,sum) for all the biggest sums
-    from items_a and items_b, in decreasing order
+    compute biggest sums from two descending ordered lists,
+    labeled by indices
+    :param items_a: list of numeric values, sorted descendingly
+    :param items_b: list of numeric values, sorted descendingly
+    :returns: list of namedtuples of the form (idx1,idx2,sum),
+    sorted by descending sum
     '''
     a_index = b_index = 0
     while a_index < len(items_a) and b_index < len(items_b):
@@ -34,6 +37,14 @@ QaAnswerLogit = namedtuple('QaAnswerLogit', [
 ])
 
 def qa_logits(start_logits, end_logits):
+    '''
+    Compute the logits for top qa pairs
+    :param start_logits: tensor from qa model output
+    :param end_logits: tensor from qa model output
+    :returns: generator of namedtuples of the form
+    (start_idx, end_idx, logit), sorted in descending order
+    by score
+    ''' 
     sorted_starts_tensors = torch.sort(start_logits, descending=True)
     sorted_ends_tensors = torch.sort(end_logits, descending=True)
     # start logits sorted in descending order INDEPENDENTLY
@@ -69,6 +80,13 @@ QaAnswer = namedtuple('QaAnswer',[
 ])
 
 def qa_probabilities(start_logits, end_logits, k):
+    '''
+    Computes the top k qa probabilities, in terms of indices.
+    :param start_logits: tensor from qa model output
+    :param end_logits: tensor from qa model output
+    :param k: number of results to return
+    :returns: list of namedtuples of the form (text,probability)
+    '''
     top_answers = [
         qa_logit
         for qa_logit, _ in zip(qa_logits(start_logits, end_logits), range(k))

--- a/happytransformer/qa_util.py
+++ b/happytransformer/qa_util.py
@@ -1,0 +1,29 @@
+from collections import namedtuple
+
+SumPair = namedtuple('SumPair',['idx1', 'idx2', 'sum'])
+
+def biggest_sums(items_a, items_b):
+    '''
+    assumes items_a and items_b sorted (descending)
+    return (idx1,idx2,sum) for all the biggest sums
+    from items_a and items_b, in decreasing order
+    '''
+    a_index = b_index = 0
+    while a_index < len(items_a) and b_index < len(items_b):
+        yield SumPair(
+            a_index, b_index,
+            sum=items_a[a_index] + items_b[b_index]
+        )
+        # increment in whichever direction has smaller gain
+        # fallback to -inf at end of list. 
+        # this will always be taken last.
+        next_from_a = items_a[a_index+1] if a_index + 1 < len(items_a) else float('-inf')
+        next_from_b = items_b[b_index+1] if b_index + 1 < len(items_b) else float('-inf')
+
+        diff_a = items_a[a_index] - next_from_a
+        diff_b = items_b[b_index] - next_from_b
+
+        if diff_a >= diff_b:
+            b_index += 1
+        else:
+            a_index += 1

--- a/happytransformer/qa_util.py
+++ b/happytransformer/qa_util.py
@@ -34,8 +34,8 @@ QaAnswerLogit = namedtuple('QaAnswerLogit', [
 ])
 
 def qa_logits(start_logits, end_logits):
-    sorted_starts_tensors = torch.sort(start_logits)
-    sorted_ends_tensors = torch.sort(end_logits)
+    sorted_starts_tensors = torch.sort(start_logits, descending=True)
+    sorted_ends_tensors = torch.sort(end_logits, descending=True)
     # start logits sorted in descending order INDEPENDENTLY
     sorted_start_scores = sorted_starts_tensors.values.tolist()
     sorted_start_indices = sorted_starts_tensors.indices.tolist()
@@ -79,7 +79,7 @@ def qa_probabilities(start_logits, end_logits, k):
         for answer in top_answers
     ])
 
-    probabilities = torch.nn.Softmax()(logit_scores).tolist()
+    probabilities = torch.nn.Softmax(dim=0)(logit_scores).tolist()
     # NOTE: throwing away indices. Do we care?
     return [
         QaProbability(

--- a/happytransformer/qa_util.py
+++ b/happytransformer/qa_util.py
@@ -80,7 +80,6 @@ def qa_probabilities(start_logits, end_logits, k):
     ])
 
     probabilities = torch.nn.Softmax(dim=0)(logit_scores).tolist()
-    # NOTE: throwing away indices. Do we care?
     return [
         QaProbability(
             start_idx=answer.start_idx,

--- a/happytransformer/qa_util.py
+++ b/happytransformer/qa_util.py
@@ -76,7 +76,7 @@ QaProbability = namedtuple('QaProbability', [
     'start_idx', 'end_idx', 'probability'
 ])
 QaAnswer = namedtuple('QaAnswer',[
-    'text', 'probability'
+    'text', 'softmax'
 ])
 
 def qa_probabilities(start_logits, end_logits, k):

--- a/happytransformer/qa_util.py
+++ b/happytransformer/qa_util.py
@@ -53,11 +53,11 @@ def qa_logits(start_logits, end_logits):
         for sum_pair in 
         biggest_sums(sorted_start_scores, sorted_end_scores)
     )
-    # filter for only answers which have end after start
+    # filter for only answers which have end at or after start
     legit_answers = (
         answer
         for answer in all_answers
-        if answer.end_idx > answer.start_idx
+        if answer.end_idx >= answer.start_idx
     )
     return legit_answers
 

--- a/happytransformer/qa_util.py
+++ b/happytransformer/qa_util.py
@@ -32,7 +32,7 @@ def biggest_sums(items_a, items_b):
         else:
             a_index += 1
 
-QaAnswerLogit = namedtuple('QaAnswerLogit', [
+QAAnswerLogit = namedtuple('QaAnswerLogit', [
     'start_idx','end_idx', 'logit'
 ])
 
@@ -56,7 +56,7 @@ def qa_logits(start_logits, end_logits):
     # start logit + end logit pairs sorted in descending order 
     # of their sum TOGETHER
     all_answers = (
-        QaAnswerLogit(
+        QAAnswerLogit(
             start_idx=sorted_start_indices[sum_pair.idx1],
             end_idx=sorted_end_indices[sum_pair.idx2],
             logit=sum_pair.sum
@@ -72,10 +72,10 @@ def qa_logits(start_logits, end_logits):
     )
     return legit_answers
 
-QaProbability = namedtuple('QaProbability', [
+QAProbability = namedtuple('QaProbability', [
     'start_idx', 'end_idx', 'probability'
 ])
-QaAnswer = namedtuple('QaAnswer',[
+QAAnswer = namedtuple('QaAnswer',[
     'text', 'softmax'
 ])
 
@@ -98,7 +98,7 @@ def qa_probabilities(start_logits, end_logits, k):
 
     probabilities = torch.nn.Softmax(dim=0)(logit_scores).tolist()
     return [
-        QaProbability(
+        QAProbability(
             start_idx=answer.start_idx,
             end_idx=answer.end_idx,
             probability=probability

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.17.4
 torch>=1.3.1
 tqdm>=4.38.0
-transformers>=2.1.1
+transformers>=4.0.0
 pandas>=0.23.0
 scikit_learn>=0.22.1

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
             'pandas',
             'tqdm',
             'scikit_learn',
-            'transformers',
+            'transformers>=4.0.0',
 
       ],
     classifiers=[

--- a/tests/test_qa_multi.py
+++ b/tests/test_qa_multi.py
@@ -6,13 +6,18 @@ PARAGRAPH = (
     'Jesus was crucified on the cross. '
     'The bible contains many stories such as this one. '
     'A variety of authors detail the events. '
-    'Britian has the largest army and France has the longest road. '
+    'Britain has the largest army and France has the longest road. '
 )
-QUESTION = 'Who has the longest road?'
+
+QA_PAIRS = [
+    ('Who has the largest army?', 'Britain'),
+    ('Who has the longest road?', 'France'),
+    ('How did Jesus die?', 'Crucified on the cross')
+]
 
 def test_qa_multi():
-    answers = happy.answers_to_question(QUESTION, PARAGRAPH)
-    print(answers)
-    print()
-    answer = happy.answer_question(QUESTION, PARAGRAPH)
-    print(answer)
+    for question, expected_answer in QA_PAIRS:
+        computed_answers = happy.answers_to_question(question, PARAGRAPH, k=10)
+        computed_answer = happy.answer_question(question, PARAGRAPH)
+        assert len(computed_answers) == 10
+        assert computed_answers[0].text.lower() == computed_answer.lower() == expected_answer.lower()

--- a/tests/test_qa_multi.py
+++ b/tests/test_qa_multi.py
@@ -1,0 +1,14 @@
+from happytransformer import HappyBERT
+
+happy = HappyBERT()
+
+PARAGRAPH = (
+    'Jesus was crucified on the cross. '
+    'The bible contains many stories such as this one. '
+    'A variety of authors detail the events. '
+)
+
+def test_qa_multi():
+    happy.answers_to_question('How did Jesus die?', PARAGRAPH)
+
+test_qa_multi()

--- a/tests/test_qa_multi.py
+++ b/tests/test_qa_multi.py
@@ -1,18 +1,19 @@
 from happytransformer import HappyBERT
 
-happy = HappyBERT('madlag/bert-base-uncased-squad-v1-sparse0.25')
+happy = HappyBERT('bert-large-uncased-whole-word-masking-finetuned-squad')
 
 PARAGRAPH = (
-    'Jesus was crucified on the cross. '
-    'The bible contains many stories such as this one. '
-    'A variety of authors detail the events. '
-    'Britain has the largest army and France has the longest road. '
+    'McGill is a university located in Montreal. '
+    'It was founded in 1821, making it the eight oldest university in Canada. '
+    'It is currently ranked 31st worldwide according to the QS Global World Ranking '
+
 )
 
 QA_PAIRS = [
-    ('Who has the largest army?', 'Britain'),
-    ('Who has the longest road?', 'France'),
-    ('How did Jesus die?', 'Crucified on the cross')
+    ('When was McGill founded?', '1821'),
+    ('Where is McGill located?', 'Montreal'),
+    ('What is McGill\'s worldwide ranking?', '31st'),
+
 ]
 
 def test_qa_multi():

--- a/tests/test_qa_multi.py
+++ b/tests/test_qa_multi.py
@@ -26,6 +26,6 @@ def test_qa_multi():
         assert computed_answers[0].text.lower() == expected_answer.lower()
         assert computed_answer.lower() == expected_answer.lower()
         
-        total_p = sum(answer.probability for answer in computed_answers)
+        total_p = sum(answer.softmax for answer in computed_answers)
         # probabilties for answers_to_question() add up to 1 ish
         assert abs(total_p-1) < 0.01

--- a/tests/test_qa_multi.py
+++ b/tests/test_qa_multi.py
@@ -19,5 +19,11 @@ def test_qa_multi():
     for question, expected_answer in QA_PAIRS:
         computed_answers = happy.answers_to_question(question, PARAGRAPH, k=10)
         computed_answer = happy.answer_question(question, PARAGRAPH)
+        # k is being respected
         assert len(computed_answers) == 10
-        assert computed_answers[0].text.lower() == computed_answer.lower() == expected_answer.lower()
+        # both answering methods yield correct result
+        assert computed_answers[0].text.lower() == expected_answer.lower()
+        assert computed_answer.lower() == expected_answer.lower()
+        total_p = sum(answer.probability for answer in computed_answers)
+        # probabilties for answers_to_question() add up to 1 ish
+        assert abs(total_p-1) < 0.01

--- a/tests/test_qa_multi.py
+++ b/tests/test_qa_multi.py
@@ -24,6 +24,7 @@ def test_qa_multi():
         # both answering methods yield correct result
         assert computed_answers[0].text.lower() == expected_answer.lower()
         assert computed_answer.lower() == expected_answer.lower()
+        
         total_p = sum(answer.probability for answer in computed_answers)
         # probabilties for answers_to_question() add up to 1 ish
         assert abs(total_p-1) < 0.01

--- a/tests/test_qa_multi.py
+++ b/tests/test_qa_multi.py
@@ -8,7 +8,7 @@ PARAGRAPH = (
     'A variety of authors detail the events. '
     'Britian has the largest army and France has the longest road. '
 )
-QUESTION = 'How did Jesus die?'
+QUESTION = 'Who has the longest road?'
 
 def test_qa_multi():
     answers = happy.answers_to_question(QUESTION, PARAGRAPH)

--- a/tests/test_qa_multi.py
+++ b/tests/test_qa_multi.py
@@ -1,13 +1,18 @@
 from happytransformer import HappyBERT
 
-happy = HappyBERT()
+happy = HappyBERT('madlag/bert-base-uncased-squad-v1-sparse0.25')
 
 PARAGRAPH = (
     'Jesus was crucified on the cross. '
     'The bible contains many stories such as this one. '
     'A variety of authors detail the events. '
+    'Britian has the largest army and France has the longest road. '
 )
+QUESTION = 'How did Jesus die?'
 
 def test_qa_multi():
-    answers = happy.answers_to_question('How did Jesus die?', PARAGRAPH)
+    answers = happy.answers_to_question(QUESTION, PARAGRAPH)
     print(answers)
+    print()
+    answer = happy.answer_question(QUESTION, PARAGRAPH)
+    print(answer)

--- a/tests/test_qa_multi.py
+++ b/tests/test_qa_multi.py
@@ -1,6 +1,10 @@
+"""
+Tests for the "answers_to_question" method that can be accessed through a HappyBERT object
+"""
+
 from happytransformer import HappyBERT
 
-happy = HappyBERT('bert-large-uncased-whole-word-masking-finetuned-squad')
+happy_bert = HappyBERT('bert-large-uncased-whole-word-masking-finetuned-squad')
 
 PARAGRAPH = (
     'McGill is a university located in Montreal. '
@@ -18,14 +22,13 @@ QA_PAIRS = [
 
 def test_qa_multi():
     for question, expected_answer in QA_PAIRS:
-        computed_answers = happy.answers_to_question(question, PARAGRAPH, k=10)
-        computed_answer = happy.answer_question(question, PARAGRAPH)
+        computed_answers = happy_bert.answers_to_question(question, PARAGRAPH, k=10)
+        computed_answer = happy_bert.answer_question(question, PARAGRAPH)
         # k is being respected
         assert len(computed_answers) == 10
         # both answering methods yield correct result
         assert computed_answers[0].text.lower() == expected_answer.lower()
         assert computed_answer.lower() == expected_answer.lower()
-        
         total_p = sum(answer.softmax for answer in computed_answers)
         # probabilties for answers_to_question() add up to 1 ish
         assert abs(total_p-1) < 0.01

--- a/tests/test_qa_multi.py
+++ b/tests/test_qa_multi.py
@@ -9,6 +9,5 @@ PARAGRAPH = (
 )
 
 def test_qa_multi():
-    happy.answers_to_question('How did Jesus die?', PARAGRAPH)
-
-test_qa_multi()
+    answers = happy.answers_to_question('How did Jesus die?', PARAGRAPH)
+    print(answers)

--- a/tests/test_qa_util.py
+++ b/tests/test_qa_util.py
@@ -1,18 +1,25 @@
+"""
+Contains tests for functions found within qa_util.py
+"""
+
 from happytransformer.qa_util import biggest_sums, SumPair
 
 def test_biggest_sums():
-    items_a = [7,4,3]
-    items_b = [7,6,4]
+    """
+    Tests the biggest_sums function
+    """
+    items_a = [7, 4, 3]
+    items_b = [7, 6, 4]
     expected_pairs = [
-        SumPair(idx1=0, idx2=0 ,sum=14), # 7+7
-        SumPair(idx1=0, idx2=1, sum=13), # 7+6
-        SumPair(idx1=0, idx2=2, sum=11), # 7+4
-        SumPair(idx1=1, idx2=2, sum=8), # 4+4
-        SumPair(idx1=2, idx2=2, sum=7) # 3+4
+        SumPair(idx1=0, idx2=0, sum=14),  # 7+7
+        SumPair(idx1=0, idx2=1, sum=13),  # 7+6
+        SumPair(idx1=0, idx2=2, sum=11),  # 7+4
+        SumPair(idx1=1, idx2=2, sum=8),  # 4+4
+        SumPair(idx1=2, idx2=2, sum=7)  # 3+4
     ]
     computed_pairs = biggest_sums(items_a, items_b)
     assert all(
-        expected_pair==computed_pair
+        expected_pair == computed_pair
         for expected_pair, computed_pair in 
         zip(expected_pairs, computed_pairs)
     )

--- a/tests/test_qa_util.py
+++ b/tests/test_qa_util.py
@@ -1,0 +1,18 @@
+from happytransformer.qa_util import biggest_sums, SumPair
+
+def test_biggest_sums():
+    items_a = [7,4,3]
+    items_b = [7,6,4]
+    expected_pairs = [
+        SumPair(idx1=0, idx2=0 ,sum=14), # 7+7
+        SumPair(idx1=0, idx2=1, sum=13), # 7+6
+        SumPair(idx1=0, idx2=2, sum=11), # 4+6
+        SumPair(idx1=1, idx2=2, sum=8), # 3+6
+        SumPair(idx1=2, idx2=2, sum=7) # 3+4
+    ]
+    computed_pairs = biggest_sums(items_a, items_b)
+    assert all(
+        expected_pair==computed_pair
+        for expected_pair, computed_pair in 
+        zip(expected_pairs, computed_pairs)
+    )

--- a/tests/test_qa_util.py
+++ b/tests/test_qa_util.py
@@ -6,8 +6,8 @@ def test_biggest_sums():
     expected_pairs = [
         SumPair(idx1=0, idx2=0 ,sum=14), # 7+7
         SumPair(idx1=0, idx2=1, sum=13), # 7+6
-        SumPair(idx1=0, idx2=2, sum=11), # 4+6
-        SumPair(idx1=1, idx2=2, sum=8), # 3+6
+        SumPair(idx1=0, idx2=2, sum=11), # 7+4
+        SumPair(idx1=1, idx2=2, sum=8), # 4+4
         SumPair(idx1=2, idx2=2, sum=7) # 3+4
     ]
     computed_pairs = biggest_sums(items_a, items_b)


### PR DESCRIPTION
Usage:
```
>>> from happytransformer import HappyBERT
>>> happy = HappyBERT()
>>> answers = happy.answers_to_question('How did Jesus die?','Jesus was crucified on the cross. Afterwards, Jesus was resurrected.',k=4)
>>> for answer in answers:
...   print(answer)
... 
QaAnswer(text='crucified on the cross', probability=0.6860016584396362)
QaAnswer(text='jesus was crucified on the cross', probability=0.23527821898460388)
QaAnswer(text='jesus was crucified', probability=0.06294126063585281)
QaAnswer(text='jesus was crucified on the cross. afterwards, jesus was resurrected', probability=0.01577887311577797)
```

closes #154

Note that the probabilities in this output are based on the assumption that the answer is within the top k answers. This assumption could be removed by considering all valid pairs, but this would likely increase processing. I'm not sure if there's a mathematical trick that could be used to circumvent this (i.e. computing the softmax without directly summing all [start,end] pairs). However, it probably isn't too important, as the less likely answers quickly become both unlikely and nonsensical. 