### PR TITLE
Standardized Outputs and Parameters 

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,20 +75,24 @@ bert_base_cased = HappyBERT("bert-base-cased")
 bert_large_uncased = HappyBERT("bert-large-uncased")
 bert_large_cased = HappyBERT("bert-large-cased")
 ```
-## Word Prediction 
+## Word Prediction
+
+It is recommended that you use HappyROBERTA("roberta-large") for masked word prediction.
+Avoid using HappyBERT for masked word prediction. 
+If you do decide to use HappyXLNET or HappyBERT, then also use their corresponding "large cased model'. 
+ 
+For all Happy Transformers, the masked token is **"[MASK]"**
+
+### Single Mask
 
 Each Happy Transformer has a public  method called "predict_mask(text, options, num_results)" with the following input arguments.
 1. Text: the text you wish to predict including a single masked token.
 2. options (default = every word): A limited set of words the model can return.
 3. num_results (default = 1): The number of returned predictions.
 
-For all Happy Transformers, the masked token is **"[MASK]"**
+returns: a list of dictionaries, where each dictionary contains a "word" and "softmax" key
 
-"predict_mask(text, options, num_results)" returns a list of dictionaries which is exemplified in Example 1 .
 
-It is recommended that you use HappyROBERTA("roberta-large") for masked word prediction.
-Avoid using HappyBERT for masked word prediction. 
-If you do decide to use HappyXLNET or HappyBERT, then also use their corresponding "large cased model'. 
 
 
 #### Example 1 :
@@ -142,6 +146,101 @@ print(type(results[1])) # prints: <class 'dict'>
 print(results[1]) # prints: {'word': 'pizza', 'softmax': 0.00017212195}
 
 ```
+
+
+### Multiple Mask
+
+The "predict_masks(text, options, num_results)" method predicts multiple masks within a string. 
+1. Text: the text you wish to predict that includes "[MASK]" at least once
+2. options: a list of lists, where each inner lists contains strings. The outer list is for each mask. The inner list is for the options for the nth mask.  
+3. num_results (default = 1): The number of returned predictions for each mask. 
+
+returns: a list of lists, where each inner list contains dictionaries.  Each dictionary has a "word" and "softmax" key
+
+The outer list is for the nth mask token. the inner list contains the the prediction(s) for the mask. 
+
+
+
+#### Example 1 :
+```sh
+from happytransformer import HappyROBERTA
+#--------------------------------------#
+happy_roberta = HappyROBERTA("roberta-large")
+text = "[MASK] have a [MASK] dog and I love [MASK] so much"
+results = happy_roberta.predict_masks(text)
+
+print(type(results))  # prints: <class 'list'>
+print(results)  # prints: [[{'word': 'i', 'softmax': 0.5861835479736328}], [{'word': 'little', 'softmax': 0.16358524560928345}], [{'word': 'him', 'softmax': 0.6039994359016418}]]
+
+first_mask_result = results[0]
+print(type(first_mask_result))  # prints: <class 'list'>
+print(first_mask_result)  # prints: [{'word': 'i', 'softmax': 0.5861835479736328}]
+
+first_prediction_result = first_mask_result[0]
+print(type(first_prediction_result))  # prints: <class 'dict'>
+print(first_prediction_result)  # prints: {'word': 'i', 'softmax': 0.5861835479736328}
+
+
+print(type(first_prediction_result["word"])) # <class 'str'>
+print(first_prediction_result["word"]) # i
+
+
+```
+
+#### Example 2 :
+```sh
+
+from happytransformer import HappyROBERTA
+#--------------------------------------#
+happy_roberta = HappyROBERTA("roberta-large")
+text = "[MASK] have a [MASK] dog and I love [MASK] so much"
+results = happy_roberta.predict_masks(text, num_results=2)
+
+print(type(results))  # prints: <class 'list'>
+print(results)  # prints: [[{'word': 'i', 'softmax': 0.5861835479736328}, {'word': 'I', 'softmax': 0.3941880762577057}], [{'word': 'little', 'softmax': 0.16358524560928345}, {'word': 'beautiful', 'softmax': 0.10422931611537933}] ...
+
+second_mask_result = results[1]
+print(type(second_mask_result))  # prints: <class 'list'>
+print(second_mask_result)  # prints: [{'word': 'little', 'softmax': 0.16358524560928345}, {'word': 'beautiful', 'softmax': 0.10422931611537933}]
+
+second_prediction_result = second_mask_result[1]
+print(type(second_prediction_result))  # prints: <class 'dict'>
+print(second_prediction_result)  # prints: {'word': 'beautiful', 'softmax': 0.10422931611537933}
+
+
+print(type(second_prediction_result["word"])) # prints: <class 'str'>
+print(second_prediction_result["word"]) # prints: beautiful
+
+
+```
+
+#### Example 3 :
+```sh
+from happytransformer import HappyROBERTA
+#--------------------------------------#
+happy_roberta = HappyROBERTA("roberta-large")
+text = "[MASK] have a [MASK] dog and I love [MASK] so much"
+
+options = [["We", "You"], ["smart", "massive"], ["him", "myself"]]
+results = happy_roberta.predict_masks(text, options=options)
+
+print(type(results))  # prints: <class 'list'>
+print(results)  # prints: [[{'word': 'We', 'softmax': 0.007347162}, {'word': 'You', 'softmax': 0.0007238558}], [{'word': 'smart', 'softmax': 1.1157575e-06}, {'word': 'massive', 'softmax': 1.0597887e-06}], [{'word': 'him', 'softmax': 0.00021874729}, {'word': 'myself', 'softmax': 3.0992996e-06}]]
+
+
+first_mask_result = results[0]
+print(type(first_mask_result))  # prints: <class 'list'>
+print(first_mask_result)  # prints: [{'word': 'We', 'softmax': 0.007347162}, {'word': 'You', 'softmax': 0.0007238558}]
+
+first_prediction_result = first_mask_result[0]
+print(type(first_prediction_result))  # prints: <class 'dict'>
+print(first_prediction_result)  # prints: {'word': 'We', 'softmax': 0.007347162}
+
+print(type(first_prediction_result["word"])) # <class 'str'>
+print(first_prediction_result["word"]) # We
+
+```
+
 ## Binary Sequence Classification 
 
 Binary sequence classification (BSC) has many applications. For example, by using BSC, you can train a model to predict if a yelp review is positive or negative. 

--- a/README.md
+++ b/README.md
@@ -381,10 +381,10 @@ print(result) # prints: bert
     2. text: The text containing the answer to the question
     3. k: The number of answers that will be returned 
 
-The output is a list of named tuples in descending order according to their probability. 
-Each tuple contains two fields: text and softmax. 
-The text field contains the answer in the form of a string. 
-The softmax field contains the "probability" of the answer as a float between 0 and 1. 
+The output is a list of  dictionaries. 
+Each dictionary contains two keys: text and softmax. 
+The text key contains the answer in the form of a string. 
+The softmax key contains the "probability" of the answer as a float between 0 and 1. 
 
 ###### Example 1:
 ```sh
@@ -395,18 +395,19 @@ question = "Who does Ernie live with?"
 text = "Ernie is an orange Muppet character on the long running PBS and HBO children's television show Sesame Street. He and his roommate Bert form the comic duo Bert and Ernie, one of the program's centerpieces, with Ernie acting the role of the naïve troublemaker and Bert the world weary foil."  # Source: https://en.wikipedia.org/wiki/Ernie_(Sesame_Street)
 result = happy_bert.answers_to_question(question, text, k=3)
 print(type(result)) # prints: <class 'list'>
-print(result) # prints: [QAAnswer(text='bert', probability=0.9916905164718628), QAAnswer(text='roommate bert', probability=0.004403269849717617), QAAnswer(text='his roommate bert', probability=0.0039062034338712692)]
+print(result) # prints: [{'text': 'bert', 'softmax': 0.9916905164718628}, {'text': 'roommate bert', 'softmax': 0.004403269849717617}, {'text': 'his roommate bert', 'softmax': 0.0039062034338712692}]
+
 
 best_answer = result[0]
 second_best_answer = result[1]
 
-print(type(best_answer)) # prints: <class 'happytransformer.qa_util.QAAnswer'>
-print(best_answer) # prints: QAAnswer(text='bert', probability=0.9916905164718628)
+print(type(best_answer)) # prints:<class 'dict'>
 
-print(best_answer.text) # prints: bert
-print(best_answer.softmax) # prints: 0.9916905164718628
-print(best_answer[0]) # prints: bert
-print(best_answer[1]) # prints:  0.9916905164718628
+print(best_answer) # prints: {'text': 'bert', 'softmax': 0.9916905164718628}
+
+print(best_answer["text"]) # prints: bert
+print(best_answer["softmax"]) # prints: 0.9916905164718628
+
 ```
 
 

--- a/happytransformer/happy_bert.py
+++ b/happytransformer/happy_bert.py
@@ -18,7 +18,7 @@ import torch
 import numpy as np
 
 from happytransformer.happy_transformer import HappyTransformer
-from happytransformer.qa_util import qa_probabilities, QAAnswer
+from happytransformer.qa_util import qa_probabilities
 
 class HappyBERT(HappyTransformer):
     """
@@ -140,7 +140,7 @@ class HappyBERT(HappyTransformer):
         :param text: The text containing the answer to the question
         :return: The answer to the given question, as a string
         """
-        return self.answers_to_question(question, text, 1)[0].text
+        return self.answers_to_question(question, text, 1)[0]["text"]
 
     def _tokenize_qa(self, question, context):
         input_text = ' '.join([
@@ -183,12 +183,11 @@ class HappyBERT(HappyTransformer):
         token_offset = sep_id_index + 1
 
         return [
-            QAAnswer(
-                text=self.tokenizer.decode(
+            {"text": self.tokenizer.decode(
                     # grab ids from start to end (inclusive) and decode to text
                     input_ids[token_offset+answer.start_idx : token_offset+answer.end_idx+1]
                 ),
-                softmax=answer.probability
-            )
+            "softmax": answer.probability}
+
             for answer in probabilities
         ]

--- a/happytransformer/happy_transformer.py
+++ b/happytransformer/happy_transformer.py
@@ -139,7 +139,7 @@ class HappyTransformer:
         '''
         return text
 
-    def predict_masks(self, text: str, masks_options=None, num_results=1):
+    def predict_masks(self, text: str, options=None, num_results=1):
         '''
         Predict multiple [MASK] tokens in some text.
         :param text: text containing the mask tokens
@@ -164,7 +164,7 @@ class HappyTransformer:
             lambda text: text == self.tokenizer.mask_token
         )
         
-        if masks_options is None: 
+        if options is None:
             return [
                 self._masked_predictions_at_index_any(
                     softmax, masked_index, num_results
@@ -176,7 +176,7 @@ class HappyTransformer:
                 self._masked_predictions_at_index_options(
                     softmax, masked_index, mask_options
                 )
-                for masked_index, mask_options in zip(masked_indices, masks_options)
+                for masked_index, mask_options in zip(masked_indices, options)
             ]
 
     def predict_mask(self, text: str, options=None, num_results=1):

--- a/happytransformer/happy_transformer.py
+++ b/happytransformer/happy_transformer.py
@@ -30,7 +30,6 @@ def _indices_where(items, predicate):
         if predicate(item)
     ]
 
-MaskedPrediction = namedtuple('MaskedPrediction',['text','probability'])
 
 _POSSIBLE_MASK_TOKENS = ['<mask>', '<MASK>', '[MASK]']
 
@@ -110,7 +109,7 @@ class HappyTransformer:
             for token in tokens
         ]
         return [
-            MaskedPrediction(option, score)
+            {"word": option, "softmax": score}
             for option, score in zip(options, scores)
         ]
 
@@ -127,7 +126,7 @@ class HappyTransformer:
             for option_id in option_ids
         ]
         return [
-            MaskedPrediction(option,score)
+            {"word": option, "softmax": score}
             for option,score in zip(options,scores)
         ]
 
@@ -279,11 +278,12 @@ class HappyTransformer:
         :return: formatted_ranked_scores: list of dictionaries of the ranked
                  scores
         """
-        ranked_scores = sorted(tupled_predicitons, key=lambda x: x[1],
+        ranked_scores = sorted(tupled_predicitons, key=lambda x: x["softmax"],
                                reverse=True)
         formatted_ranked_scores = list()
-        for word, softmax in ranked_scores:
-            formatted_ranked_scores.append({'word': word, 'softmax': softmax})
+        for dic in ranked_scores:
+
+            formatted_ranked_scores.append({'word': dic["word"], 'softmax': dic["softmax"]})
         return formatted_ranked_scores
 
     def _softmax(self, value):

--- a/happytransformer/qa_util.py
+++ b/happytransformer/qa_util.py
@@ -83,10 +83,6 @@ QAProbability = namedtuple('QaProbability', [
 ])
 
 
-QAAnswer = namedtuple('QaAnswer', [
-    'text', 'softmax'
-])
-
 def qa_probabilities(start_logits, end_logits, k):
     """
     Computes the top k qa probabilities, in terms of indices.

--- a/tests/test_multi_mask.py
+++ b/tests/test_multi_mask.py
@@ -14,16 +14,16 @@ def test_multi_mask():
         len(specific_predictions) == 2
         for specific_predictions in all_predictions
     )
-    assert all_predictions[0][0].text == 'i'
-    assert all_predictions[0][0].probability > 0.5
+    assert all_predictions[0][0]["word"] == 'i'
+    assert all_predictions[0][0]["softmax"] > 0.5
 
-    assert all_predictions[2][0].text == 'him'
+    assert all_predictions[2][0]["word"] == 'him'
 
 def test_multi_mask_options():
     MASKS_OPTIONS = [
-        ['I','You'],
-        ['big','small'],
-        ['him','her']
+        ['I', 'You'],
+        ['big', 'small'],
+        ['him', 'her']
     ]
     options_set = set(
         option
@@ -34,10 +34,9 @@ def test_multi_mask_options():
         "[MASK] have a [MASK] dog and I love [MASK] so much",
         masks_options=MASKS_OPTIONS
     )
-    print(all_predictions)
     assert len(all_predictions) == 3
     assert all(
-        prediction.text in options_set
+        prediction["word"] in options_set
         for mask_predictions in all_predictions
         for prediction in mask_predictions
     )

--- a/tests/test_multi_mask.py
+++ b/tests/test_multi_mask.py
@@ -32,7 +32,7 @@ def test_multi_mask_options():
     )
     all_predictions = happy.predict_masks(
         "[MASK] have a [MASK] dog and I love [MASK] so much",
-        masks_options=MASKS_OPTIONS
+        options=MASKS_OPTIONS
     )
     assert len(all_predictions) == 3
     assert all(

--- a/tests/test_qa_multi.py
+++ b/tests/test_qa_multi.py
@@ -27,8 +27,8 @@ def test_qa_multi():
         # k is being respected
         assert len(computed_answers) == 10
         # both answering methods yield correct result
-        assert computed_answers[0].text.lower() == expected_answer.lower()
+        assert computed_answers[0]["text"].lower() == expected_answer.lower()
         assert computed_answer.lower() == expected_answer.lower()
-        total_p = sum(answer.softmax for answer in computed_answers)
+        total_p = sum(answer["softmax"] for answer in computed_answers)
         # probabilties for answers_to_question() add up to 1 ish
         assert abs(total_p-1) < 0.01


### PR DESCRIPTION
I believe it is best to stick to returning dictionaries for public methods that return multiple values to avoid confusion. We can discuss using a custom output class or using named tuples (as @ted537) suggested for the next major release.

I also noticed that the option parameter for predict_masks was named "masks_options" instead of "options" as per the predict_mask method. 

Changes: 
1. Changed predict_masks output from a list of lists that contain named tuples to a list of lists that contain dictionaries (similar to predict_mask).
2. Changed the answers_to_questions output from a list of named tuples to a list of dictionaries
3. Changed predict_masks "masks_options" parameter to "options" (to match predict_mask)
4. Added predict_masks() section to README
5. Updated readme documentation for answers_to_questions
6. Updated test cases answers_to_questions
7. Updated test cases for predict_masks