### PR TITLE
Converting To Named Tuple Outputs

### DIFF
--- a/happytransformer/happy_question_answering.py
+++ b/happytransformer/happy_question_answering.py
@@ -110,7 +110,7 @@ class HappyQuestionAnswering(HappyTransformer):
         return: A dictionary that contains a key called "eval_loss"
 
         """
-        return self._trainer.eval(input_filepath=input_filepath,)
+        return self._trainer.eval(input_filepath=input_filepath)
 
     def test(self, input_filepath):
         """

--- a/happytransformer/happy_question_answering.py
+++ b/happytransformer/happy_question_answering.py
@@ -2,11 +2,10 @@
 Contains the HappyQuestionAnswering class.
 
 """
-
+from collections import namedtuple
 import torch
 from happytransformer.happy_transformer import HappyTransformer
 from happytransformer.qa.trainer import QATrainer
-from collections import namedtuple
 from happytransformer.qa.default_args \
     import ARGS_QA_TRAIN
 from transformers import (
@@ -19,7 +18,7 @@ from transformers import (
     QuestionAnsweringPipeline,
 )
 
-QuestionAnsweringResult = namedtuple("QuestionAnsweringResult", [ "answer", "score", "start", "end"])
+QuestionAnsweringResult = namedtuple("QuestionAnsweringResult", ["answer", "score", "start", "end"])
 
 class HappyQuestionAnswering(HappyTransformer):
     """

--- a/happytransformer/happy_question_answering.py
+++ b/happytransformer/happy_question_answering.py
@@ -6,6 +6,7 @@ Contains the HappyQuestionAnswering class.
 import torch
 from happytransformer.happy_transformer import HappyTransformer
 from happytransformer.qa.trainer import QATrainer
+from collections import namedtuple
 from happytransformer.qa.default_args \
     import ARGS_QA_TRAIN
 from transformers import (
@@ -18,7 +19,7 @@ from transformers import (
     QuestionAnsweringPipeline,
 )
 
-
+QuestionAnsweringResult = namedtuple("QuestionAnsweringResult", [ "answer", "score", "start", "end"])
 
 class HappyQuestionAnswering(HappyTransformer):
     """
@@ -61,14 +62,28 @@ class HappyQuestionAnswering(HappyTransformer):
 
     def answer_question(self, context, question, topk=1):
         """
-
         :param context: background information to answer the question (string)
         :param question: A question that can be answered with the given context (string)
         :param topk: how many results
-        :return: if topk =1, a dictionary that contains the keys: score, start, end and answer
-        if topk >1, a list of dictionaries described above
+        :return: A list of a named tuples that contains the keys: answer, score, start and end
+
         """
-        return self._pipeline(context=context, question=question, topk=topk)
+
+        result = self._pipeline(context=context, question=question, topk=topk)
+        # transformers returns a single dictionary when topk ==1.
+        # Our convention however is to have constant output format
+        if topk == 1:
+            result = [result]
+
+        results = [
+            QuestionAnsweringResult(
+                answer=answer["answer"],
+                score=answer["score"],
+                start=answer["start"],
+                end=answer["end"],)
+            for answer in result
+        ]
+        return results
 
     def train(self, input_filepath, args=ARGS_QA_TRAIN):
         """
@@ -109,4 +124,4 @@ class HappyQuestionAnswering(HappyTransformer):
         return: A list of dictionaries. Each dictionary
         contains the keys: "score", "start", "end" and "answer"
         """
-        return self._trainer.test(input_filepath=input_filepath, pipeline=self._pipeline)
+        return self._trainer.test(input_filepath=input_filepath, solve=self.answer_question)

--- a/happytransformer/happy_text_classification.py
+++ b/happytransformer/happy_text_classification.py
@@ -67,11 +67,11 @@ class HappyTextClassification(HappyTransformer):
         # Blocking allowing a for a list of strings
         if not isinstance(text, str):
             raise ValueError("the \"text\" argument must be a single string")
-        result = self._pipeline(text)
+        results = self._pipeline(text)
         # we do not support predicting a list of  texts, so only first prediction is relevant
-        result = result[0]
+        first_result = results[0]
 
-        return TextClassificationResult(label=result["label"], score=result["score"])
+        return TextClassificationResult(label=first_result["label"], score=first_result["score"])
 
 
     def train(self, input_filepath, args=ARGS_TC_TRAIN):

--- a/happytransformer/happy_trainer.py
+++ b/happytransformer/happy_trainer.py
@@ -23,11 +23,11 @@ class HappyTrainer:
         """
         raise NotImplementedError()
 
-    def test(self, input_filepath, pipeline):
+    def test(self, input_filepath, solve):
         """
 
         :param input_filepath: A string to file location
-        :param pipeline: an initialized transformer pipeline for the given task
+        :param solve: a method for using the model for the given task
         :return: test results
         """
         raise NotImplementedError()

--- a/happytransformer/happy_trainer.py
+++ b/happytransformer/happy_trainer.py
@@ -1,10 +1,12 @@
 """
 Parent class for training classes, such as TCTrainer and QATrainer
 """
-
+from collections import  namedtuple
 import tempfile
 from transformers import TrainingArguments, Trainer
 
+# may eventually add more metrics like accuracy
+EvalResult = namedtuple("EvalResult", ["eval_loss"])
 
 class HappyTrainer:
     def __init__(self, model, model_type, tokenizer, device, logger):

--- a/happytransformer/qa/trainer.py
+++ b/happytransformer/qa/trainer.py
@@ -46,7 +46,7 @@ class QATrainer(HappyTrainer):
         return self._run_eval(dataset)
 
 
-    def test(self, input_filepath, pipeline):
+    def test(self, input_filepath, solve):
         """
         See docstring in HappyQuestionAnswering.test()
 
@@ -58,7 +58,7 @@ class QATrainer(HappyTrainer):
         for case in tqdm(zip(contexts, questions)):
             context = case[0]
             question = case[1]
-            result = pipeline(question, context)
+            result = solve(context, question)[0]  # only care about first result
 
             results.append(result)
 

--- a/happytransformer/qa/trainer.py
+++ b/happytransformer/qa/trainer.py
@@ -10,7 +10,7 @@ https://huggingface.co/transformers/custom_datasets.html#question-answering-with
 import csv
 from tqdm import tqdm
 import torch
-from happytransformer.happy_trainer import HappyTrainer
+from happytransformer.happy_trainer import HappyTrainer, EvalResult
 
 class QATrainer(HappyTrainer):
     """
@@ -42,8 +42,9 @@ class QATrainer(HappyTrainer):
         self.__add_end_idx(contexts, answers)
         encodings = self.tokenizer(contexts, questions, truncation=True, padding=True)
         self.__add_token_positions(encodings, answers)
-        dataset = QuestionAnsweringDataset(encodings)
-        return self._run_eval(dataset)
+        eval_dataset = QuestionAnsweringDataset(encodings)
+        result = self._run_eval(eval_dataset)
+        return EvalResult(eval_loss=result["eval_loss"])
 
 
     def test(self, input_filepath, solve):

--- a/happytransformer/tc/trainer.py
+++ b/happytransformer/tc/trainer.py
@@ -32,7 +32,7 @@ class TCTrainer(HappyTrainer):
 
         return self._run_eval(eval_dataset)
 
-    def test(self, input_filepath, pipeline):
+    def test(self, input_filepath, solve):
         """
         See docstring in HappyQuestionAnswering.test()
         solve: HappyQuestionAnswering.answers_to_question()
@@ -42,7 +42,7 @@ class TCTrainer(HappyTrainer):
         results = list()
 
         for context in tqdm(contexts):
-            result = pipeline(context)
+            result = solve(context)
             results.append(result)
 
         return results

--- a/happytransformer/tc/trainer.py
+++ b/happytransformer/tc/trainer.py
@@ -31,7 +31,6 @@ class TCTrainer(HappyTrainer):
         eval_dataset = TextClassificationDataset(eval_encodings, labels)
 
         result = self._run_eval(eval_dataset)
-        print(result)
         return EvalResult(eval_loss=result["eval_loss"])
 
     def test(self, input_filepath, solve):

--- a/happytransformer/tc/trainer.py
+++ b/happytransformer/tc/trainer.py
@@ -9,7 +9,7 @@ https://huggingface.co/transformers/custom_datasets.html#sequence-classification
 
 import csv
 import torch
-from happytransformer.happy_trainer import HappyTrainer
+from happytransformer.happy_trainer import HappyTrainer, EvalResult
 from tqdm import tqdm
 
 
@@ -30,7 +30,9 @@ class TCTrainer(HappyTrainer):
         eval_encodings = self.tokenizer(contexts, truncation=True, padding=True)
         eval_dataset = TextClassificationDataset(eval_encodings, labels)
 
-        return self._run_eval(eval_dataset)
+        result = self._run_eval(eval_dataset)
+        print(result)
+        return EvalResult(eval_loss=result["eval_loss"])
 
     def test(self, input_filepath, solve):
         """

--- a/tests/test_qa.py
+++ b/tests/test_qa.py
@@ -28,7 +28,7 @@ def test_qa_train():
 def test_qa_eval():
     happy_qa = HappyQuestionAnswering()
     result = happy_qa.eval("../data/qa/train-eval.csv")
-    assert result["eval_loss"] == 0.11738169193267822
+    assert result.eval_loss == 0.11738169193267822
 
 
 def test_qa_test():
@@ -46,9 +46,9 @@ def test_qa_train_effectiveness():
     """
 
     happy_qa = HappyQuestionAnswering()
-    before_loss = happy_qa.eval("../data/qa/train-eval.csv")["eval_loss"]
+    before_loss = happy_qa.eval("../data/qa/train-eval.csv").eval_loss
     happy_qa.train("../data/qa/train-eval.csv")
-    after_loss = happy_qa.eval("../data/qa/train-eval.csv")["eval_loss"]
+    after_loss = happy_qa.eval("../data/qa/train-eval.csv").eval_loss
 
     assert after_loss < before_loss
 
@@ -59,9 +59,9 @@ def test_qa_train_effectiveness_albert():
     """
 
     happy_qa = HappyQuestionAnswering("ALBERT", "twmkn9/albert-base-v2-squad2")
-    before_loss = happy_qa.eval("../data/qa/train-eval.csv")["eval_loss"]
+    before_loss = happy_qa.eval("../data/qa/train-eval.csv").eval_loss
     happy_qa.train("../data/qa/train-eval.csv")
-    after_loss = happy_qa.eval("../data/qa/train-eval.csv")["eval_loss"]
+    after_loss = happy_qa.eval("../data/qa/train-eval.csv").eval_loss
 
     assert after_loss < before_loss
 
@@ -80,9 +80,9 @@ def test_qa_train_effectiveness_bert():
     """
 
     happy_qa = HappyQuestionAnswering("BERT", "mrm8488/bert-tiny-5-finetuned-squadv2")
-    before_loss = happy_qa.eval("../data/qa/train-eval.csv")["eval_loss"]
+    before_loss = happy_qa.eval("../data/qa/train-eval.csv").eval_loss
     happy_qa.train("../data/qa/train-eval.csv")
-    after_loss = happy_qa.eval("../data/qa/train-eval.csv")["eval_loss"]
+    after_loss = happy_qa.eval("../data/qa/train-eval.csv").eval_loss
 
     assert after_loss < before_loss
 

--- a/tests/test_qa.py
+++ b/tests/test_qa.py
@@ -2,22 +2,22 @@
 Tests for the question answering training, evaluating and testing functionality
 """
 
-from happytransformer.happy_question_answering import HappyQuestionAnswering
+from happytransformer.happy_question_answering import HappyQuestionAnswering, QuestionAnsweringResult
 
 
 def test_qa_answer_question():
     happy_qa = HappyQuestionAnswering()
     result = happy_qa.answer_question("Today's date is January 8th 2021", "What is the date?")
-    answer = {'score': 0.9696964621543884, 'start': 16, 'end': 32, 'answer': 'January 8th 2021'}
+    answer = [QuestionAnsweringResult(answer='January 8th 2021', score=0.9696964621543884, start=16, end=32)]
     assert result == answer
 
 
 def test_qa_answer_question_top_k():
     happy_qa = HappyQuestionAnswering()
     result = happy_qa.answer_question("Today's date is January 8th 2021", "What is the date?", topk=3)
-    answer = [{'score': 0.9696964621543884, 'start': 16, 'end': 32, 'answer': 'January 8th 2021'},
-              {'score': 0.02050216868519783, 'start': 16, 'end': 27, 'answer': 'January 8th'},
-              {'score': 0.005092293489724398, 'start': 16, 'end': 23, 'answer': 'January'}]
+    answer = [QuestionAnsweringResult(answer='January 8th 2021', score=0.9696964621543884, start=16, end=32),
+              QuestionAnsweringResult(answer='January 8th', score=0.02050216868519783, start=16, end=27),
+              QuestionAnsweringResult(answer='January', score=0.005092293489724398, start=16, end=23)]
     assert result == answer
 
 def test_qa_train():
@@ -34,8 +34,8 @@ def test_qa_eval():
 def test_qa_test():
     happy_qa = HappyQuestionAnswering()
     result = happy_qa.test("../data/qa/test.csv")
-    answer = [{'score': 0.9939756989479065, 'start': 0, 'end': 12, 'answer': 'October 31st'},
-              {'score': 0.967872679233551, 'start': 12, 'end': 25, 'answer': 'November 23rd'}]
+    answer = [QuestionAnsweringResult(answer='October 31st', score=0.9939756989479065, start=0, end=12),
+              QuestionAnsweringResult(answer='November 23rd', score=0.967872679233551, start=12, end=25)]
     assert result == answer
 
 
@@ -68,8 +68,8 @@ def test_qa_train_effectiveness_albert():
 def test_qa_test_albert():
     happy_qa = HappyQuestionAnswering("ALBERT", "twmkn9/albert-base-v2-squad2")
     result = happy_qa.test("../data/qa/test.csv")
-    answer = [{'score': 0.988578736782074, 'start': 0, 'end': 12, 'answer': 'October 31st'},
-              {'score': 0.9833534359931946, 'start': 12, 'end': 25, 'answer': 'November 23rd'}]
+    answer = [QuestionAnsweringResult(answer='October 31st', score=0.988578736782074, start=0, end=12),
+              QuestionAnsweringResult(answer='November 23rd', score=0.9833534359931946, start=12, end=25)]
     assert result == answer
 
 
@@ -89,6 +89,6 @@ def test_qa_train_effectiveness_bert():
 def test_qa_test_bert():
     happy_qa = HappyQuestionAnswering("BERT", "mrm8488/bert-tiny-5-finetuned-squadv2")
     result = happy_qa.test("../data/qa/test.csv")
-    answer = [{'score': 0.9352769255638123, 'start': 0, 'end': 12, 'answer': 'October 31st'},
-              {'score': 0.9180678129196167, 'start': 12, 'end': 25, 'answer': 'November 23rd'}]
+    answer = [QuestionAnsweringResult(answer='October 31st', score=0.9352769255638123, start=0, end=12),
+              QuestionAnsweringResult(answer='November 23rd', score=0.9180678129196167, start=12, end=25)]
     assert result == answer

--- a/tests/test_tc.py
+++ b/tests/test_tc.py
@@ -2,7 +2,7 @@
 Tests for Text Classification Functionality
 """
 
-from happytransformer.happy_text_classification import HappyTextClassification
+from happytransformer.happy_text_classification import HappyTextClassification, TextClassificationResult
 
 def test_classify_text():
     """
@@ -12,23 +12,9 @@ def test_classify_text():
     """
     happy_tc = HappyTextClassification()
     result = happy_tc.classify_text("What a great movie")
-    print(result)
-    answer = [{'label': 'POSITIVE', 'score': 0.9998726844787598}]
+    answer = TextClassificationResult(label='POSITIVE', score=0.9998726844787598)
     assert result == answer
 
-def test_classify_texts():
-    """
-    Tests
-    HappyQuestionAnswering.classify_text()
-
-    """
-    happy_tc = HappyTextClassification()
-    input = ["What a great movie", "Horrible movie", "Bad restaurant"]
-    result = happy_tc.classify_text(input)
-    answer = [{'label': 'POSITIVE', 'score': 0.9998726844787598},
-              {'label': 'NEGATIVE', 'score': 0.9997945427894592},
-              {'label': 'NEGATIVE', 'score': 0.9997393488883972}]
-    assert result == answer
 
 def test_qa_train():
     """
@@ -59,10 +45,10 @@ def test_qa_test():
     happy_tc = HappyTextClassification()
 
     result = happy_tc.test("../data/tc/test.csv")
-    answer = [[{'label': 'POSITIVE', 'score': 0.9998401999473572}],
-              [{'label': 'NEGATIVE', 'score': 0.9772131443023682}],
-              [{'label': 'NEGATIVE', 'score': 0.9966067671775818}],
-              [{'label': 'POSITIVE', 'score': 0.9792295098304749}]]
+    answer = [TextClassificationResult(label='POSITIVE', score=0.9998401999473572),
+              TextClassificationResult(label='NEGATIVE', score=0.9772131443023682),
+              TextClassificationResult(label='NEGATIVE', score=0.9966067671775818),
+              TextClassificationResult(label='POSITIVE', score=0.9792295098304749)]
     assert result == answer
 
 
@@ -87,10 +73,10 @@ def test_qa_test_albert():
     happy_tc = HappyTextClassification(model_type="ALBERT", model_name="textattack/albert-base-v2-SST-2")
 
     result = happy_tc.test("../data/tc/test.csv")
-    answer = [[{'label': 'LABEL_1', 'score': 0.9990348815917969}],
-              [{'label': 'LABEL_0', 'score': 0.9947203397750854}],
-              [{'label': 'LABEL_0', 'score': 0.9958302974700928}],
-              [{'label': 'LABEL_1', 'score': 0.9986426830291748}]]
+    answer = [TextClassificationResult(label='LABEL_1', score=0.9990348815917969),
+              TextClassificationResult(label='LABEL_0', score=0.9947203397750854),
+              TextClassificationResult(label='LABEL_0', score=0.9958302974700928),
+              TextClassificationResult(label='LABEL_1', score=0.9986426830291748)]
     assert result == answer
 
 
@@ -116,10 +102,10 @@ def test_qa_test_bert():
     happy_tc = HappyTextClassification(model_type="BERT", model_name="textattack/bert-base-uncased-SST-2")
 
     result = happy_tc.test("../data/tc/test.csv")
-    answer = [[{'label': 'LABEL_1', 'score': 0.9995690584182739}],
-              [{'label': 'LABEL_0', 'score': 0.9981549382209778}],
-              [{'label': 'LABEL_0', 'score': 0.9965545535087585}],
-              [{'label': 'LABEL_1', 'score': 0.9978235363960266}]]
+    answer = [TextClassificationResult(label='LABEL_1', score=0.9995690584182739),
+              TextClassificationResult(label='LABEL_0', score=0.9981549382209778),
+              TextClassificationResult(label='LABEL_0', score=0.9965545535087585),
+              TextClassificationResult(label='LABEL_1', score=0.9978235363960266)]
     assert result == answer
 
 

--- a/tests/test_tc.py
+++ b/tests/test_tc.py
@@ -34,7 +34,7 @@ def test_qa_eval():
     """
     happy_tc = HappyTextClassification()
     results = happy_tc.eval("../data/tc/train-eval.csv")
-    assert results["eval_loss"] == 0.007262040860950947
+    assert results.eval_loss == 0.007262040860950947
 
 
 def test_qa_test():
@@ -88,9 +88,9 @@ def test_qa_train_effectiveness_albert():
     """
 
     happy_tc = HappyTextClassification(model_type="ALBERT", model_name="textattack/albert-base-v2-SST-2")
-    before_loss = happy_tc.eval("../data/tc/train-eval.csv")["eval_loss"]
+    before_loss = happy_tc.eval("../data/tc/train-eval.csv").eval_loss
     happy_tc.train("../data/tc/train-eval.csv")
-    after_loss = happy_tc.eval("../data/tc/train-eval.csv")["eval_loss"]
+    after_loss = happy_tc.eval("../data/tc/train-eval.csv").eval_loss
     assert after_loss < before_loss
 
 
@@ -117,7 +117,7 @@ def test_qa_train_effectiveness_bert():
     """
 
     happy_tc = HappyTextClassification(model_type="BERT", model_name="textattack/bert-base-uncased-SST-2")
-    before_loss = happy_tc.eval("../data/tc/train-eval.csv")["eval_loss"]
+    before_loss = happy_tc.eval("../data/tc/train-eval.csv").eval_loss
     happy_tc.train("../data/tc/train-eval.csv")
-    after_loss = happy_tc.eval("../data/tc/train-eval.csv")["eval_loss"]
+    after_loss = happy_tc.eval("../data/tc/train-eval.csv").eval_loss
     assert after_loss < before_loss


### PR DESCRIPTION
**Changes**
1. QA: answer_question() now outputs a a list of named tuples, instead of a list of dictionaries 
2. QA: answer_question() now always outputs a lists tuples, even when topk ==1
3. QA: test now uses answer_question() instead of a pipeline
4. QA: eval now returns a named tuple
5. TC: classify_text() now always returns a single named tuple. Before it allowed for multiple test cases to be fed in at the same time and returned dictionaries. 
6. TC: test now uses classify_text() instead of a pipeline
7. TC: eval now returns a named tuple
8. Updated test cases for QA and TC to reflect these changes 
