### PR TITLE
Multi-Label Text Classification and README Additions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,11 @@ Initialization Arguments:
        [MODELS](https://huggingface.co/models?filter=text-classification)
     3. num_labels(int): The number of text categories. The default is 2
     
-# WARNING: If you try to load a pretrained model that has a different number of categories 
-# than num_labels, then you will get an error 
+WARNING: If you try to load a pretrained model that has a different number of categories 
+than num_labels, then you will get an error 
 
-# "albert-base-v2", "bert-base-uncased" and "distilbert-base-uncased" do not have a predefined 
-# number of labels, so if you use these models you can set num_labels freely 
+"albert-base-v2", "bert-base-uncased" and "distilbert-base-uncased" do not have a predefined 
+number of labels, so if you use these models you can set num_labels freely 
 
 ### Initialization  
 

--- a/README.md
+++ b/README.md
@@ -185,8 +185,6 @@ Input:
 
 Returns: 
 A label in the form of a string, typically "LABEL_x", where x is the label number.
-Some models use different labels 
-
 
 #### Example 2.1:
 ```python

--- a/README.md
+++ b/README.md
@@ -60,15 +60,15 @@ pip install happytransformer
 
 ## Word Prediction
 
-Initialize a HappyWordPrediction() object to perform word prediction. 
+Initialize a HappyWordPrediction object to perform word prediction. 
 
-Initialization Arguments: 
-    1. model_type (string): either "ALBERT", "BERT" or "DISTILBERT." The default is "DISTILBERT"
-    2. model_name(string): below is a URL that contains potential models. 
+**Initialization Arguments:**
+ 1. model_type (string): either "ALBERT", "BERT" or "DISTILBERT." The default is "DISTILBERT"
+ 2. model_name(string): below is a URL that contains potential models. 
        [MODELS](https://huggingface.co/models?filter=masked-lm)
  
 
-For all Transformers, the masked token is **"[MASK]"**
+Note: For all Transformers, the masked token is **"[MASK]"**
 
 ### Initialization  
 
@@ -143,28 +143,25 @@ print(result[1].token_str)  # technology
 ## Text Classification 
 
 
-Initialize a HappyTextClassification() object to perform text classification. 
+Initialize a HappyTextClassification object to perform text classification. 
 
 This model assigns a label to a given text string. For example, you can train a model to 
 detect if an email is spam based on its text. 
 
 
-Initialization Arguments: 
-    1. model_type (string): either "ALBERT", "BERT" or "DISTILBERT." The default is "DISTILBERT"
-    2. model_name(string): below is a URL that contains potential models. The default is "distilbert-base-uncased"
+**Initialization Arguments:** 
+1. model_type (string): either "ALBERT", "BERT" or "DISTILBERT." The default is "DISTILBERT"
+2. model_name(string): below is a URL that contains potential models. The default is "distilbert-base-uncased"
        [MODELS](https://huggingface.co/models?filter=text-classification)
-    3. num_labels(int): The number of text categories. The default is 2
+3. num_labels(int): The number of text categories. The default is 2
     
 WARNING: If you try to load a pretrained model that has a different number of categories 
 than num_labels, then you will get an error 
 
-"albert-base-v2", "bert-base-uncased" and "distilbert-base-uncased" do not have a predefined 
+NOTE: "albert-base-v2", "bert-base-uncased" and "distilbert-base-uncased" do not have a predefined 
 number of labels, so if you use these models you can set num_labels freely 
 
 ### Initialization  
-
-"HappyTextClassification("ALBERT", "textattack/albert-base-v2-SST-2")"  has many useful applications. 
-It's able to detect the sentiment of text.  
 
 
 #### Example 2.0:
@@ -215,6 +212,8 @@ inputs:
 The dictionary below shows the default values. 
 
 Information about what the keys mean can be accessed [here](https://huggingface.co/transformers/main_classes/trainer.html#transformers.TrainingArguments)
+```python
+
 ARGS_QA_TRAIN= {
     'learning_rate': 5e-5,
     'weight_decay': 0,
@@ -225,6 +224,7 @@ ARGS_QA_TRAIN= {
     'num_train_epochs': 3.0,
 
 }
+```
 
 Output: None
  
@@ -330,16 +330,16 @@ The list is in order by ascending csv index.
 ```
 ## Question Answering
 
-Initialize a HappyQuestionAnswering() object to perform question answering. 
+Initialize a HappyQuestionAnswering object to perform question answering. 
 
 This model answers a question given a body of that's text relevant to the questions. 
 
 The outputted answer is always a text-span with the provided information. 
 
-Initialization Arguments: 
-    1. model_type (string): either "ALBERT", "BERT" or "DISTILBERT." The default is "DISTILBERT"
-    2. model_name(string): below is a URL that contains potential models. 
-       [MODELS](https://huggingface.co/models?filter=question-answering)
+**Initialization Arguments:**
+1. model_type (string): either "ALBERT", "BERT" or "DISTILBERT." The default is "DISTILBERT"
+2. model_name(string): below is a URL that contains potential models. 
+   [MODELS](https://huggingface.co/models?filter=question-answering)
 
 ### Initialization  
 
@@ -410,6 +410,8 @@ inputs:
 The dictionary below shows the default values. 
 
 Information about what the keys mean can be accessed [here](https://huggingface.co/transformers/main_classes/trainer.html#transformers.TrainingArguments)
+```python
+
 ARGS_QA_TRAIN= {
     'learning_rate': 5e-5,
     'weight_decay': 0,
@@ -420,7 +422,7 @@ ARGS_QA_TRAIN= {
     'num_train_epochs': 3.0,
 
 }
-
+```
 Output: None
  
 #### Table 3.1

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ pip install happytransformer
 
 
 ## Word Prediction
+### Initialization  
 
 Initialize a HappyWordPrediction object to perform word prediction. 
 
@@ -70,7 +71,6 @@ Initialize a HappyWordPrediction object to perform word prediction.
 
 Note: For all Transformers, the masked token is **"[MASK]"**
 
-### Initialization  
 
 We recommend using "HappyWordPrediction("ALBERT", "albert-xxlarge-v2")" for the best performance 
 
@@ -142,6 +142,7 @@ print(result[1].token_str)  # technology
 ```
 ## Text Classification 
 
+### Initialization  
 
 Initialize a HappyTextClassification object to perform text classification. 
 
@@ -160,8 +161,6 @@ than num_labels, then you will get an error
 
 NOTE: "albert-base-v2", "bert-base-uncased" and "distilbert-base-uncased" do not have a predefined 
 number of labels, so if you use these models you can set num_labels freely 
-
-### Initialization  
 
 
 #### Example 2.0:
@@ -330,6 +329,7 @@ The list is in order by ascending csv index.
 ```
 ## Question Answering
 
+### Initialization  
 Initialize a HappyQuestionAnswering object to perform question answering. 
 
 This model answers a question given a body of that's text relevant to the questions. 
@@ -341,7 +341,6 @@ The outputted answer is always a text-span with the provided information.
 2. model_name(string): below is a URL that contains potential models. 
    [MODELS](https://huggingface.co/models?filter=question-answering)
 
-### Initialization  
 
 We recommend using "HappyQuestionAnswering("ALBERT", "mfeb/albert-xxlarge-v2-squad2")" for the best performance 
 

--- a/README.md
+++ b/README.md
@@ -310,6 +310,26 @@ The list is in order by ascending csv index.
 
 
 ```
+
+
+#### Example 2.5:
+```python
+    from happytransformer import HappyTextClassification
+    # --------------------------------------#
+    happy_tc = HappyTextClassification(model_type="DISTILBERT",
+                                       model_name="distilbert-base-uncased-finetuned-sst-2-english",
+                                       num_labels=2)  # Don't forget to set num_labels!
+    before_loss = happy_tc.eval("../../data/tc/train-eval.csv").eval_loss
+    happy_tc.train("../../data/tc/train-eval.csv")
+    after_loss = happy_tc.eval("../../data/tc/train-eval.csv").eval_loss
+    print("Before loss: ", before_loss)  # 0.007262040860950947
+    print("After loss: ", after_loss)  # 0.000162081079906784
+    # Since after_loss < before_loss, the model learned!
+    # Note: typically you evaluate with a separate dataset
+    # but for simplicity we used the same one
+
+
+```
 ## Question Answering
 
 Initialize a HappyQuestionAnswering() object to perform question answering. 

--- a/data/tc/test-multi.csv
+++ b/data/tc/test-multi.csv
@@ -1,0 +1,7 @@
+text
+Wow what a great place to eat
+Soooo good
+Okay place
+Pretty average
+Horrible food
+Yuck

--- a/data/tc/train-eval-multi.csv
+++ b/data/tc/train-eval-multi.csv
@@ -1,0 +1,7 @@
+text,label
+Wow what a great place to eat,2
+Soooo good,2
+Okay place,1
+Pretty average,1
+Horrible food,0
+Yuck,0

--- a/examples/text_classification/readme_examples.py
+++ b/examples/text_classification/readme_examples.py
@@ -1,0 +1,66 @@
+
+from happytransformer import HappyTextClassification
+
+def example_2_0():
+    happy_qa_distilbert = HappyTextClassification()  # default with "distilbert-base-uncased"
+    happy_tc_albert = HappyTextClassification(model_type="ALBERT", model_name="albert-base-v2")
+    happy_qa_bert = HappyTextClassification("BERT", "bert-base-uncased")
+
+
+def example_2_1():
+    happy_tc = HappyTextClassification(model_type="DISTILBERT",  model_name="distilbert-base-uncased-finetuned-sst-2-english")
+    result = happy_tc.classify_text("Great movie! 5/5")
+    print(type(result))  # <class 'happytransformer.happy_text_classification.TextClassificationResult'>
+    print(result)  # TextClassificationResult(label='LABEL_1', score=0.9998761415481567)
+    print(result.label)  # LABEL_1
+
+
+def example_2_2():
+    happy_tc = HappyTextClassification(model_type="DISTILBERT",
+                                       model_name="distilbert-base-uncased-finetuned-sst-2-english",
+                                       num_labels=2)  # Don't forget to set num_labels!
+    happy_tc.train("../../data/tc/train-eval.csv")
+
+
+def example_2_3():
+    happy_tc = HappyTextClassification(model_type="DISTILBERT",
+                                       model_name="distilbert-base-uncased-finetuned-sst-2-english",
+                                       num_labels=2)  # Don't forget to set num_labels!
+    result = happy_tc.eval("../../data/tc/train-eval.csv")
+    print(type(result))  # <class 'happytransformer.happy_trainer.EvalResult'>
+    print(result)  # EvalResult(eval_loss=0.007262040860950947)
+    print(result.eval_loss)  # 0.007262040860950947
+
+
+def example_2_4():
+    happy_tc = HappyTextClassification(model_type="DISTILBERT",
+                                       model_name="distilbert-base-uncased-finetuned-sst-2-english",
+                                       num_labels=2)  # Don't forget to set num_labels!
+    result = happy_tc.test("../../data/tc/test.csv")
+    print(type(result))  # <class 'list'>
+    print(result)  # [TextClassificationResult(label='LABEL_1', score=0.9998401999473572), TextClassificationResult(label='LABEL_0', score=0.9772131443023682)...
+    print(type(result[0]))  # <class 'happytransformer.happy_text_classification.TextClassificationResult'>
+    print(result[0])  # TextClassificationResult(label='LABEL_1', score=0.9998401999473572)
+    print(result[0].label)  # LABEL_1
+
+
+def example_2_5():
+    happy_tc = HappyTextClassification(model_type="DISTILBERT",
+                                       model_name="distilbert-base-uncased-finetuned-sst-2-english",
+                                       num_labels=2)  # Don't forget to set num_labels!
+    before_loss = happy_tc.eval("../../data/tc/train-eval.csv").eval_loss
+    happy_tc.train("../../data/tc/train-eval.csv")
+    after_loss = happy_tc.eval("../../data/tc/train-eval.csv").eval_loss
+    print("Before loss: ", before_loss)  # 0.007262040860950947
+    print("After loss: ", after_loss)  # 0.000162081079906784
+    # Since after_loss < before_loss, the model learned!
+    # Note: typically you evaluate with a separate dataset
+    # but for simplicity we used the same one
+
+
+def main():
+    example_2_0()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/text_classification/readme_examples.py
+++ b/examples/text_classification/readme_examples.py
@@ -59,7 +59,7 @@ def example_2_5():
 
 
 def main():
-    example_2_0()
+    example_2_5()
 
 
 if __name__ == "__main__":

--- a/happytransformer/happy_text_classification.py
+++ b/happytransformer/happy_text_classification.py
@@ -11,9 +11,8 @@ from transformers import (
     DistilBertTokenizerFast,
     AlbertForSequenceClassification,
     AlbertTokenizerFast,
-
-
-    TextClassificationPipeline
+AutoConfig,
+TextClassificationPipeline
 )
 from happytransformer.tc.trainer import TCTrainer
 
@@ -29,18 +28,20 @@ class HappyTextClassification(HappyTransformer):
     """
 
     def __init__(self, model_type="DISTILBERT",
-                 model_name="distilbert-base-uncased-finetuned-sst-2-english"):
+                 model_name="distilbert-base-uncased", num_labels=2):
         model = None
         tokenizer = None
+        config = AutoConfig.from_pretrained(model_name, num_labels=num_labels)
+        # config = DistilBertConfig(num_labels=num_labels)
 
         if model_type == "ALBERT":
-            model = AlbertForSequenceClassification.from_pretrained(model_name)
+            model = AlbertForSequenceClassification.from_pretrained(model_name, config=config)
             tokenizer = AlbertTokenizerFast.from_pretrained(model_name)
         elif model_type == "BERT":
-            model = BertForSequenceClassification.from_pretrained(model_name)
+            model = BertForSequenceClassification.from_pretrained(model_name, config=config)
             tokenizer = BertTokenizerFast.from_pretrained(model_name)
         elif model_type == "DISTILBERT":
-            model = DistilBertForSequenceClassification.from_pretrained(model_name)
+            model = DistilBertForSequenceClassification.from_pretrained(model_name, config=config)
             tokenizer = DistilBertTokenizerFast.from_pretrained(model_name)
 
         else:

--- a/happytransformer/happy_text_classification.py
+++ b/happytransformer/happy_text_classification.py
@@ -32,7 +32,6 @@ class HappyTextClassification(HappyTransformer):
         model = None
         tokenizer = None
         config = AutoConfig.from_pretrained(model_name, num_labels=num_labels)
-        # config = DistilBertConfig(num_labels=num_labels)
 
         if model_type == "ALBERT":
             model = AlbertForSequenceClassification.from_pretrained(model_name, config=config)

--- a/tests/test_tc.py
+++ b/tests/test_tc.py
@@ -10,7 +10,7 @@ def test_classify_text():
     HappyQuestionAnswering.classify_text()
 
     """
-    happy_tc = HappyTextClassification()
+    happy_tc = HappyTextClassification(model_type="DISTILBERT",  model_name="distilbert-base-uncased-finetuned-sst-2-english")
     result = happy_tc.classify_text("What a great movie")
     answer = TextClassificationResult(label='LABEL_1', score=0.9998726844787598)
     assert result == answer

--- a/tests/test_tc.py
+++ b/tests/test_tc.py
@@ -12,7 +12,7 @@ def test_classify_text():
     """
     happy_tc = HappyTextClassification()
     result = happy_tc.classify_text("What a great movie")
-    answer = TextClassificationResult(label='POSITIVE', score=0.9998726844787598)
+    answer = TextClassificationResult(label='LABEL_1', score=0.9998726844787598)
     assert result == answer
 
 
@@ -22,7 +22,8 @@ def test_qa_train():
     HappyQuestionAnswering.train()
 
     """
-    happy_tc = HappyTextClassification()
+    happy_tc = HappyTextClassification(model_type="DISTILBERT",
+                 model_name="distilbert-base-uncased-finetuned-sst-2-english")
 
     happy_tc.train("../data/tc/train-eval.csv")
 
@@ -32,7 +33,8 @@ def test_qa_eval():
     Tests
     HappyQuestionAnswering.eval()
     """
-    happy_tc = HappyTextClassification()
+    happy_tc = HappyTextClassification(model_type="DISTILBERT",
+                 model_name="distilbert-base-uncased-finetuned-sst-2-english")
     results = happy_tc.eval("../data/tc/train-eval.csv")
     assert results.eval_loss == 0.007262040860950947
 
@@ -42,13 +44,14 @@ def test_qa_test():
     Tests
     HappyQuestionAnswering.test()
     """
-    happy_tc = HappyTextClassification()
+    happy_tc = HappyTextClassification(model_type="DISTILBERT",
+                 model_name="distilbert-base-uncased-finetuned-sst-2-english")
 
     result = happy_tc.test("../data/tc/test.csv")
-    answer = [TextClassificationResult(label='POSITIVE', score=0.9998401999473572),
-              TextClassificationResult(label='NEGATIVE', score=0.9772131443023682),
-              TextClassificationResult(label='NEGATIVE', score=0.9966067671775818),
-              TextClassificationResult(label='POSITIVE', score=0.9792295098304749)]
+    answer = [TextClassificationResult(label='LABEL_1', score=0.9998401999473572),
+              TextClassificationResult(label='LABEL_0', score=0.9772131443023682),
+              TextClassificationResult(label='LABEL_0', score=0.9966067671775818),
+              TextClassificationResult(label='LABEL_1', score=0.9792295098304749)]
     assert result == answer
 
 
@@ -59,11 +62,78 @@ def test_qa_train_effectiveness():
     lowering the loss as determined by HappyQuestionAnswering.eval()
     """
 
-    happy_tc = HappyTextClassification()
-    before_loss = happy_tc.eval("../data/tc/train-eval.csv")["eval_loss"]
+    happy_tc = HappyTextClassification(model_type="DISTILBERT",
+                 model_name="distilbert-base-uncased-finetuned-sst-2-english")
+    before_loss = happy_tc.eval("../data/tc/train-eval.csv").eval_loss
     happy_tc.train("../data/tc/train-eval.csv")
-    after_loss = happy_tc.eval("../data/tc/train-eval.csv")["eval_loss"]
+    after_loss = happy_tc.eval("../data/tc/train-eval.csv").eval_loss
     assert after_loss < before_loss
+
+
+
+def test_qa_train_effectiveness_multi():
+    """
+    Tests
+    Ensures that HappyQuestionAnswering.train() results in
+    lowering the loss as determined by HappyQuestionAnswering.eval()
+    """
+
+    happy_tc = HappyTextClassification(model_type="DISTILBERT",
+                 model_name="distilbert-base-uncased", num_labels=3)
+    before_loss = happy_tc.eval("../data/tc/train-eval-multi.csv").eval_loss
+    happy_tc.train("../data/tc/train-eval-multi.csv")
+    after_loss = happy_tc.eval("../data/tc/train-eval-multi.csv").eval_loss
+    assert after_loss < before_loss
+
+
+def test_qa_test_multi_distil_bert():
+    """
+    Tests
+    Ensures that HappyQuestionAnswering.train() results in
+    lowering the loss as determined by HappyQuestionAnswering.eval()
+    """
+
+    happy_tc = HappyTextClassification(model_type="DISTILBERT",
+                 model_name="distilbert-base-uncased", num_labels=3)
+    happy_tc.train("../data/tc/train-eval-multi.csv")
+    result = happy_tc.test("../data/tc/test-multi.csv")
+    answer = [TextClassificationResult(label='LABEL_2', score=0.3558128774166107),
+              TextClassificationResult(label='LABEL_2', score=0.34425610303878784),
+              TextClassificationResult(label='LABEL_1', score=0.3998771607875824),
+              TextClassificationResult(label='LABEL_1', score=0.38578158617019653),
+              TextClassificationResult(label='LABEL_0', score=0.39120176434516907),
+              TextClassificationResult(label='LABEL_0', score=0.3762877583503723)]
+    assert result == answer
+
+
+def test_qa_effectiveness_multi_albert():
+    """
+    Tests
+    Ensures that HappyQuestionAnswering.train() results in
+    lowering the loss as determined by HappyQuestionAnswering.eval()
+    """
+
+    happy_tc = HappyTextClassification(model_type="ALBERT",
+                 model_name="albert-base-v2", num_labels=3)
+    before_loss = happy_tc.eval("../data/tc/train-eval-multi.csv").eval_loss
+    happy_tc.train("../data/tc/train-eval-multi.csv")
+    after_loss = happy_tc.eval("../data/tc/train-eval-multi.csv").eval_loss
+    assert after_loss < before_loss
+
+def test_qa_effectiveness_multi_bert():
+    """
+    Tests
+    Ensures that HappyQuestionAnswering.train() results in
+    lowering the loss as determined by HappyQuestionAnswering.eval()
+    """
+
+    happy_tc = HappyTextClassification(model_type="BERT",
+                 model_name="bert-base-uncased", num_labels=3)
+    before_loss = happy_tc.eval("../data/tc/train-eval-multi.csv").eval_loss
+    happy_tc.train("../data/tc/train-eval-multi.csv")
+    after_loss = happy_tc.eval("../data/tc/train-eval-multi.csv").eval_loss
+    assert after_loss < before_loss
+
 
 def test_qa_test_albert():
     """


### PR DESCRIPTION
- Completed the TC section of the README
- Added TC README examples to "examples/text-classification/readme-examples.py"
- Changed default model for TC to a non fine-tuned DISTILBERT model
- Added num-labels argument to HappyTextClassification 
- Added lots of new tests under "test/test_tc.py" to ensure multi-label predictions work on all three models 
- Added new testing data under "data/tc/test-multi.py" and "data/tc/train-eval-multi.py"
- Adding a config file with default values except for num_labels solved the "problem" of "distilbert-base-uncased-finetuned-sst-2-english" outputting "POSITIVE" and "NEGATIVE", while other models similar models were outputting "LABEL_0" and  "LABEL_1" 