### PR TITLE
Added Token Classification & Simplified Intitialzaiton 

### DIFF
--- a/happytransformer/__init__.py
+++ b/happytransformer/__init__.py
@@ -2,5 +2,6 @@ from happytransformer.happy_question_answering import HappyQuestionAnswering
 from happytransformer.happy_word_prediction import HappyWordPrediction
 from happytransformer.happy_text_classification import HappyTextClassification
 from happytransformer.happy_next_sentence import HappyNextSentence
+from happytransformer.happy_token_classification import HappyTokenClassification
 
 name = "happytransformer"

--- a/happytransformer/adaptors/__init__.py
+++ b/happytransformer/adaptors/__init__.py
@@ -5,7 +5,8 @@ ADAPTORS = {
     'BERT': BertAdaptor(),
     'DISTILBERT': DistilBertAdaptor(),
     'ROBERTA': RobertaAdaptor(),
-    'ALBERT': AlbertAdaptor()
+    'ALBERT': AlbertAdaptor(),
+
 }
 
 def get_adaptor(model_type:str)->Adaptor:

--- a/happytransformer/adaptors/__init__.py
+++ b/happytransformer/adaptors/__init__.py
@@ -1,11 +1,9 @@
 from .adaptor import Adaptor
-from .berts import BertAdaptor, DistilBertAdaptor, RobertaAdaptor, AlbertAdaptor
+from .berts import RobertaAdaptor, AlbertAdaptor
 
 ADAPTORS = {
-    'BERT': BertAdaptor(),
-    'DISTILBERT': DistilBertAdaptor(),
-    'ROBERTA': RobertaAdaptor(),
     'ALBERT': AlbertAdaptor(),
+    'ROBERTA': RobertaAdaptor(),
 
 }
 
@@ -13,4 +11,5 @@ def get_adaptor(model_type:str)->Adaptor:
     if model_type in ADAPTORS:
         return ADAPTORS[model_type]
     else:
-        raise ValueError(f'Model type <{model_type}> not currently supported')
+        # Default for models with no special cases
+        return Adaptor()

--- a/happytransformer/adaptors/adaptor.py
+++ b/happytransformer/adaptors/adaptor.py
@@ -29,6 +29,10 @@ class Adaptor:
     def SequenceClassification(self) -> Type[PreTrainedModel]:
         raise ValueError('This model does not support sequence classification')
 
+    @property
+    def TokenClassification(self) -> Type[PreTrainedModel]:
+        raise ValueError('This model does not support sequence classification')
+
     def preprocess_mask_text(self, text: str)-> str:
         return text
 

--- a/happytransformer/adaptors/adaptor.py
+++ b/happytransformer/adaptors/adaptor.py
@@ -1,40 +1,14 @@
-from typing import Type
-from transformers import PreTrainedModel
-from transformers.tokenization_utils import PreTrainedTokenizerBase
 
 class Adaptor:
     '''
     Holds a few functions for implementation details.
     Does NOT store any state.
     '''
-    @property
-    def Tokenizer(self) -> Type[PreTrainedTokenizerBase]:
-        # this should be NotImplementedError because
-        # all Adaptors should have a Tokenizer
-        raise NotImplementedError()
 
-    @property
-    def MaskedLM(self) -> Type[PreTrainedModel]:
-        raise ValueError('This model does not support word prediction')
-
-    @property
-    def NextSentencePrediction(self) -> Type[PreTrainedModel]:
-        raise ValueError('This model does not support next sentence prediction')
-
-    @property
-    def QuestionAnswering(self) -> Type[PreTrainedModel]:
-        raise ValueError('This model does not support question answering')
-
-    @property
-    def SequenceClassification(self) -> Type[PreTrainedModel]:
-        raise ValueError('This model does not support sequence classification')
-
-    @property
-    def TokenClassification(self) -> Type[PreTrainedModel]:
-        raise ValueError('This model does not support sequence classification')
-
-    def preprocess_mask_text(self, text: str)-> str:
+    @staticmethod
+    def preprocess_mask_text(text: str) -> str:
         return text
 
-    def postprocess_mask_prediction_token(self, text: str) -> str:
+    @staticmethod
+    def postprocess_mask_prediction_token(text: str) -> str:
         return text

--- a/happytransformer/adaptors/berts.py
+++ b/happytransformer/adaptors/berts.py
@@ -2,16 +2,18 @@ from .adaptor import Adaptor
 from transformers import (
     BertForMaskedLM, BertTokenizerFast,
     BertForNextSentencePrediction, BertForQuestionAnswering,
-    BertForSequenceClassification,
+    BertForSequenceClassification, BertForTokenClassification,
 
     DistilBertForMaskedLM, DistilBertTokenizerFast,
     DistilBertForSequenceClassification, DistilBertForQuestionAnswering,
+    DistilBertForTokenClassification,
 
     RobertaForMaskedLM, RobertaTokenizerFast,
     RobertaForQuestionAnswering, RobertaForSequenceClassification,
+    RobertaForTokenClassification,
 
     AlbertForMaskedLM, AlbertTokenizerFast, AlbertForQuestionAnswering,
-    AlbertForSequenceClassification
+    AlbertForSequenceClassification,     AlbertForTokenClassification,
 )
 
 class BertAdaptor(Adaptor):
@@ -20,18 +22,22 @@ class BertAdaptor(Adaptor):
     NextSentencePrediction = BertForNextSentencePrediction
     QuestionAnswering = BertForQuestionAnswering
     SequenceClassification = BertForSequenceClassification
+    TokenClassification = BertForTokenClassification
 
 class DistilBertAdaptor(Adaptor):
     Tokenizer = DistilBertTokenizerFast
     MaskedLM = DistilBertForMaskedLM
     QuestionAnswering = DistilBertForQuestionAnswering
     SequenceClassification = DistilBertForSequenceClassification
+    TokenClassification = DistilBertForTokenClassification
+
 
 class RobertaAdaptor(Adaptor):
     Tokenizer = RobertaTokenizerFast
     MaskedLM = RobertaForMaskedLM
     QuestionAnswering = RobertaForQuestionAnswering
     SequenceClassification = RobertaForSequenceClassification
+    TokenClassification = RobertaForTokenClassification
 
     @staticmethod
     def preprocess_mask_text(text):
@@ -46,7 +52,8 @@ class AlbertAdaptor(Adaptor):
     MaskedLM = AlbertForMaskedLM
     QuestionAnswering = AlbertForQuestionAnswering
     SequenceClassification = AlbertForSequenceClassification
-    
+    TokenClassification = AlbertForTokenClassification
+
     @staticmethod
     def postprocess_mask_prediction_token(text):
         return text[1:] if text[0] == "▁" else text

--- a/happytransformer/adaptors/berts.py
+++ b/happytransformer/adaptors/berts.py
@@ -1,46 +1,11 @@
 from .adaptor import Adaptor
-from transformers import (
-    BertForMaskedLM, BertTokenizerFast,
-    BertForNextSentencePrediction, BertForQuestionAnswering,
-    BertForSequenceClassification, BertForTokenClassification,
 
-    DistilBertForMaskedLM, DistilBertTokenizerFast,
-    DistilBertForSequenceClassification, DistilBertForQuestionAnswering,
-    DistilBertForTokenClassification,
-
-    RobertaForMaskedLM, RobertaTokenizerFast,
-    RobertaForQuestionAnswering, RobertaForSequenceClassification,
-    RobertaForTokenClassification,
-
-    AlbertForMaskedLM, AlbertTokenizerFast, AlbertForQuestionAnswering,
-    AlbertForSequenceClassification, AlbertForTokenClassification,
-)
-
-class BertAdaptor(Adaptor):
-    Tokenizer = BertTokenizerFast
-    MaskedLM = BertForMaskedLM
-    NextSentencePrediction = BertForNextSentencePrediction
-    QuestionAnswering = BertForQuestionAnswering
-    SequenceClassification = BertForSequenceClassification
-    TokenClassification = BertForTokenClassification
-
-class DistilBertAdaptor(Adaptor):
-    Tokenizer = DistilBertTokenizerFast
-    MaskedLM = DistilBertForMaskedLM
-    QuestionAnswering = DistilBertForQuestionAnswering
-    SequenceClassification = DistilBertForSequenceClassification
-    TokenClassification = DistilBertForTokenClassification
 
 
 class RobertaAdaptor(Adaptor):
-    Tokenizer = RobertaTokenizerFast
-    MaskedLM = RobertaForMaskedLM
-    QuestionAnswering = RobertaForQuestionAnswering
-    SequenceClassification = RobertaForSequenceClassification
-    TokenClassification = RobertaForTokenClassification
 
     @staticmethod
-    def preprocess_mask_text(text):
+    def preprocess_mask_text(text: str) -> str:
         return text.replace('[MASK]', '<mask>')
 
     @staticmethod
@@ -48,12 +13,6 @@ class RobertaAdaptor(Adaptor):
         return text[1:] if text[0] == "Ġ" else text
 
 class AlbertAdaptor(Adaptor):
-    Tokenizer = AlbertTokenizerFast
-    MaskedLM = AlbertForMaskedLM
-    QuestionAnswering = AlbertForQuestionAnswering
-    SequenceClassification = AlbertForSequenceClassification
-    TokenClassification = AlbertForTokenClassification
-
     @staticmethod
     def postprocess_mask_prediction_token(text):
         return text[1:] if text[0] == "▁" else text

--- a/happytransformer/adaptors/berts.py
+++ b/happytransformer/adaptors/berts.py
@@ -13,7 +13,7 @@ from transformers import (
     RobertaForTokenClassification,
 
     AlbertForMaskedLM, AlbertTokenizerFast, AlbertForQuestionAnswering,
-    AlbertForSequenceClassification,     AlbertForTokenClassification,
+    AlbertForSequenceClassification, AlbertForTokenClassification,
 )
 
 class BertAdaptor(Adaptor):

--- a/happytransformer/happy_next_sentence.py
+++ b/happytransformer/happy_next_sentence.py
@@ -1,5 +1,5 @@
 import torch
-
+from transformers import AutoModelForNextSentencePrediction
 from happytransformer.happy_transformer import HappyTransformer
 from happytransformer.adaptors import get_adaptor
 
@@ -11,9 +11,8 @@ class HappyNextSentence(HappyTransformer):
                  model_name="bert-base-uncased"):
 
         self.adaptor = get_adaptor(model_type)
-        model = self.adaptor.NextSentencePrediction.from_pretrained(model_name)
-        tokenizer = self.adaptor.Tokenizer.from_pretrained(model_name)
-        super().__init__(model_type, model_name, model, tokenizer)
+        model = AutoModelForNextSentencePrediction.from_pretrained(model_name)
+        super().__init__(model_type, model_name, model)
         self._pipeline = None
         self._trainer = None
 
@@ -23,9 +22,9 @@ class HappyNextSentence(HappyTransformer):
         Higher probabilities indicate more coherent sentence pairs.
         """
 
-        encoded = self._tokenizer(sentence_a, sentence_b, return_tensors='pt')
+        encoded = self.tokenizer(sentence_a, sentence_b, return_tensors='pt')
         with torch.no_grad():
-            scores = self._model(encoded['input_ids'], token_type_ids=encoded['token_type_ids']).logits[0]
+            scores = self.model(encoded['input_ids'], token_type_ids=encoded['token_type_ids']).logits[0]
 
         probabilities = torch.softmax(scores, dim=0)
         # probability that sentence B follows sentence A

--- a/happytransformer/happy_question_answering.py
+++ b/happytransformer/happy_question_answering.py
@@ -4,7 +4,7 @@ Contains the HappyQuestionAnswering class.
 """
 from typing import List
 from dataclasses import dataclass
-from transformers import QuestionAnsweringPipeline
+from transformers import QuestionAnsweringPipeline, AutoModelForQuestionAnswering, AutoTokenizer
 
 from happytransformer.happy_transformer import HappyTransformer
 from happytransformer.qa.trainer import QATrainer
@@ -35,15 +35,15 @@ class HappyQuestionAnswering(HappyTransformer):
                  model_name="distilbert-base-cased-distilled-squad"):
         
         self.adaptor = get_adaptor(model_type)
-        model = self.adaptor.QuestionAnswering.from_pretrained(model_name)
-        tokenizer = self.adaptor.Tokenizer.from_pretrained(model_name)
 
-        super().__init__(model_type, model_name, model, tokenizer)
+        model = AutoModelForQuestionAnswering.from_pretrained(model_name)
+
+        super().__init__(model_type, model_name, model)
         device_number = detect_cuda_device_number()
 
-        self._pipeline = QuestionAnsweringPipeline(model=model, tokenizer=tokenizer, device=device_number)
+        self._pipeline = QuestionAnsweringPipeline(model=self.model, tokenizer=self.tokenizer, device=device_number)
 
-        self._trainer = QATrainer(model, model_type, tokenizer, self._device, self.logger)
+        self._trainer = QATrainer(self.model, model_type, self.tokenizer, self._device, self.logger)
 
     def answer_question(self, context: str, question: str, top_k: int = 1) \
             -> List[QuestionAnsweringResult]:

--- a/happytransformer/happy_text_classification.py
+++ b/happytransformer/happy_text_classification.py
@@ -2,9 +2,9 @@
 Contains a class called HappyTextClassification that performs text classification
 """
 from dataclasses import dataclass
-
 import torch
-from transformers import TextClassificationPipeline, AutoConfig
+
+from transformers import TextClassificationPipeline, AutoConfig, AutoModelForSequenceClassification
 
 from happytransformer.tc.trainer import TCTrainer
 from happytransformer.cuda_detect import detect_cuda_device_number
@@ -27,20 +27,19 @@ class HappyTextClassification(HappyTransformer):
         self.adaptor = get_adaptor(model_type)
         config = AutoConfig.from_pretrained(model_name, num_labels=num_labels)
 
-        model = self.adaptor.SequenceClassification.from_pretrained(model_name, config=config)
-        tokenizer = self.adaptor.Tokenizer.from_pretrained(model_name)
+        model = AutoModelForSequenceClassification.from_pretrained(model_name, config=config)
 
-        super().__init__(model_type, model_name, model, tokenizer)
+        super().__init__(model_type, model_name, model)
 
         device_number = detect_cuda_device_number()
         self._pipeline = TextClassificationPipeline(
-            model=model, tokenizer=tokenizer, 
+            model=self.model, tokenizer=self.tokenizer,
             device=device_number
         )
 
         self._trainer = TCTrainer(
-            self._model, self.model_type, 
-            self._tokenizer, self._device, self.logger
+            self.model, self.model_type,
+            self.tokenizer, self._device, self.logger
         )
 
     def classify_text(self, text: str) -> TextClassificationResult:

--- a/happytransformer/happy_token_classification.py
+++ b/happytransformer/happy_token_classification.py
@@ -22,15 +22,14 @@ class HappyTokenClassification(HappyTransformer):
         self.adaptor = get_adaptor(model_type)
 
         model = AutoModelForTokenClassification.from_pretrained(model_name)
-        tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=True)
 
-        super().__init__(model_type, model_name, model, tokenizer)
+        super().__init__(model_type, model_name, model)
 
         device_number = detect_cuda_device_number()
 
-        self._pipeline = TokenClassificationPipeline(model=model, tokenizer=tokenizer, device=device_number)
+        self._pipeline = TokenClassificationPipeline(model=self.model, tokenizer=self.tokenizer, device=device_number)
 
-        self._trainer = TOCTrainer(model, model_type, tokenizer, self._device, self.logger)
+        self._trainer = TOCTrainer(self.model, model_type, self.tokenizer, self._device, self.logger)
 
 
     def classify_token(self, text: str) -> str:

--- a/happytransformer/happy_token_classification.py
+++ b/happytransformer/happy_token_classification.py
@@ -1,0 +1,56 @@
+from typing import List, Optional
+from dataclasses import dataclass
+
+from transformers import TokenClassificationPipeline, AutoModelForTokenClassification, AutoTokenizer, AutoModel
+
+from happytransformer.happy_transformer import HappyTransformer
+from happytransformer.toc.trainer import TOCTrainer
+from happytransformer.cuda_detect import detect_cuda_device_number
+from happytransformer.adaptors import get_adaptor
+
+@dataclass
+class TokenClassificationResult:
+    tokens: List[str]
+
+class HappyTokenClassification(HappyTransformer):
+    """
+    A user facing class for text classification
+    """
+    def __init__(
+        self, model_type: str = "BERT", model_name: str = "dslim/bert-base-NER"):
+
+        self.adaptor = get_adaptor(model_type)
+
+        model = AutoModelForTokenClassification.from_pretrained(model_name)
+        tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=True)
+
+        super().__init__(model_type, model_name, model, tokenizer)
+
+        device_number = detect_cuda_device_number()
+
+        self._pipeline = TokenClassificationPipeline(model=model, tokenizer=tokenizer, device=device_number)
+
+        self._trainer = TOCTrainer(model, model_type, tokenizer, self._device, self.logger)
+
+
+    def classify_token(self, text: str) -> str:
+        """
+
+        :param text: Text that contains tokens to be classified
+        :return:
+        """
+        if not isinstance(text, str):
+            raise ValueError('the "text" argument must be a single string')
+        results = self._pipeline(text)
+
+        return results
+
+
+    def train(self, input_filepath, args):
+        raise NotImplementedError("train() is currently not available")
+
+    def eval(self, input_filepath):
+        raise NotImplementedError("eval() is currently not available")
+
+    def test(self, input_filepath):
+        raise NotImplementedError("test() is currently not available")

--- a/happytransformer/happy_transformer.py
+++ b/happytransformer/happy_transformer.py
@@ -6,6 +6,7 @@ Contains shared variables and methods for these classes.
 """
 import logging
 import torch
+from transformers import  AutoTokenizer
 
 class HappyTransformer():
     """
@@ -14,14 +15,12 @@ class HappyTransformer():
 
     """
 
-    model_type_error = "model_type must be ALBERT, BERT or DISTILBERT"
-
-    def __init__(self, model_type, model_name, model, tokenizer):
+    def __init__(self, model_type, model_name, model):
         self.model_type = model_type  # BERT, #DISTILBERT, ROBERTA, ALBERT etc
         self.model_name = model_name
-        self._model = model
-        self._tokenizer = tokenizer
-        self._model.eval()
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.model = model
+        self.model.eval()
         self._trainer = None  # initialized in child class
 
         # todo  change logging system
@@ -42,7 +41,7 @@ class HappyTransformer():
         )
 
         if self._device == 'cuda':
-            self._model.to(self._device)
+            self.model.to(self._device)
         self.logger.info("Using model: %s", self._device)
 
 

--- a/happytransformer/happy_word_prediction.py
+++ b/happytransformer/happy_word_prediction.py
@@ -1,7 +1,7 @@
 from typing import List,Optional
 from dataclasses import dataclass
 
-from transformers import FillMaskPipeline
+from transformers import FillMaskPipeline, AutoModelForMaskedLM
 
 from happytransformer.happy_transformer import HappyTransformer
 from happytransformer.mwp.trainer import WPTrainer
@@ -21,16 +21,14 @@ class HappyWordPrediction(HappyTransformer):
         self, model_type: str = "DISTILBERT", model_name: str = "distilbert-base-uncased"):
 
         self.adaptor = get_adaptor(model_type)
-        model = self.adaptor.MaskedLM.from_pretrained(model_name)
-        tokenizer = self.adaptor.Tokenizer.from_pretrained(model_name)
-
-        super().__init__(model_type, model_name, model, tokenizer)
+        model = AutoModelForMaskedLM.from_pretrained(model_name)
+        super().__init__(model_type, model_name, model)
 
         device_number = detect_cuda_device_number()
 
-        self._pipeline = FillMaskPipeline(model=model, tokenizer=tokenizer, device=device_number)
+        self._pipeline = FillMaskPipeline(model=self.model, tokenizer=self.tokenizer, device=device_number)
 
-        self._trainer = WPTrainer(model, model_type, tokenizer, self._device, self.logger)
+        self._trainer = WPTrainer(self.model, model_type, self.tokenizer, self._device, self.logger)
 
     def predict_mask(self, text: str, targets: Optional[List[str]] = None, top_k: int = 1) -> List[WordPredictionResult]:
         """

--- a/happytransformer/toc/__init__.py
+++ b/happytransformer/toc/__init__.py
@@ -1,0 +1,4 @@
+from .trainer import TOCTrainer
+from .default_args import ARGS_TOC_TRAIN
+
+name = "happytransformer.toc"

--- a/happytransformer/toc/default_args.py
+++ b/happytransformer/toc/default_args.py
@@ -1,0 +1,10 @@
+ARGS_TOC_TRAIN = {
+    'learning_rate': 5e-5,
+    'weight_decay': 0,
+    'adam_beta1': 0.9,
+    'adam_beta2': 0.999,
+    'adam_epsilon': 1e-8,
+    'max_grad_norm':  1.0,
+    'num_train_epochs': 3.0,
+
+}

--- a/happytransformer/toc/trainer.py
+++ b/happytransformer/toc/trainer.py
@@ -1,0 +1,14 @@
+from happytransformer.happy_trainer import HappyTrainer
+from happytransformer.toc.default_args import ARGS_TOC_TRAIN
+
+
+class TOCTrainer(HappyTrainer):
+
+    def train(self, input_filepath, args=ARGS_TOC_TRAIN):
+        raise NotImplementedError()
+
+    def eval(self, input_filepath):
+        raise NotImplementedError()
+
+    def test(self, input_filepath, pipeline):
+        raise NotImplemented

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+import sys
+sys.path.append('../')

--- a/tests/test_qa.py
+++ b/tests/test_qa.py
@@ -40,9 +40,8 @@ def test_qa_train_effectiveness():
     Ensures that HappyQuestionAnswering.train() results in
     lowering the loss as determined by HappyQuestionAnswering.eval()
     """
-
     # use a non-fine-tuned model so we DEFINITELY get an improvement
-    happy_qa = HappyQuestionAnswering('BERT', 'bert-base-cased')
+    happy_qa = HappyQuestionAnswering('BERT', 'mrm8488/bert-tiny-5-finetuned-squadv2')
     before_loss = happy_qa.eval("../data/qa/train-eval.csv").loss
     happy_qa.train("../data/qa/train-eval.csv")
     after_loss = happy_qa.eval("../data/qa/train-eval.csv").loss

--- a/tests/test_toc.py
+++ b/tests/test_toc.py
@@ -1,0 +1,13 @@
+from happytransformer import HappyTokenClassification
+
+
+
+def test_classify_text():
+    happy_toc = HappyTokenClassification(model_type="BERT", model_name="dslim/bert-base-NER")
+    expected_result = [{'word': 'Geoffrey', 'score': 0.9988969564437866, 'entity': 'B-PER', 'index': 4, 'start': 11, 'end': 19},
+     {'word': 'Toronto', 'score': 0.9993201494216919, 'entity': 'B-LOC', 'index': 9, 'start': 34, 'end': 41}]
+
+    result = happy_toc.classify_token("My name is Geoffrey and I live in Toronto")
+
+    assert result == expected_result
+

--- a/tests/test_wp.py
+++ b/tests/test_wp.py
@@ -8,7 +8,8 @@ def test_mwp_basic():
     MODELS = [
         ('DISTILBERT', 'distilbert-base-uncased', 'pepper'),
         ('BERT', 'bert-base-uncased', '.'),
-        ('ALBERT', 'albert-base-v2', 'garlic')
+        ('ALBERT', 'albert-base-v2', 'garlic'),
+        ('ROBERTA', "roberta-base", "pepper")
     ]
     for model_type, model_name, top_result in MODELS:
         happy_mwp = HappyWordPrediction(model_type, model_name)


### PR DESCRIPTION
**Changes:** 

- Implemented AutoTokenizer.from_pretrained() rather than implementing a specific tokenizer for each model type. 
- Likewise, implemented  methods like "AutoModelForNextSentencePrediction.from_pretrained()" and "AutoModelForQuestionAnswering.from_pretrained()"
- Added HappyTokenClassification()

**Tests**
- This PR effects everything, but does not cause any breaking changes. So, I ran all of the current tests and they passed 
- Made minor adjustments to old tests. Changes what models are used. 
- Also added new tests under test_toc.py


**Next Steps:** 
- Follow [this](https://huggingface.co/transformers/custom_datasets.html#token-classification-with-w-nut-emerging-entities) tutorial to implement fine-tuning for TOC 
- Update README and examples folder 

**Potential changes:** 
We could potentially further simplify it by using AutoModel instead of specific AutoModel classes. But, with the current implementation, invalid model types will be caught right away. For example, if someone tried to use a QA model for TC, then it would be caught during initialization which is much better than having it cause an error further on. 