### PR TITLE
Updated Minimum Version For Hugging Face's Transformer Library 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) 
 [![Downloads](https://pepy.tech/badge/happytransformer)](https://pepy.tech/project/happytransformer)
 [![Website shields.io](https://img.shields.io/website-up-down-green-red/http/shields.io.svg)](http://happytransformer.com)
-
+![version](https://img.shields.io/badge/version-2.2.1-blue)
 # Happy Transformer 
 **Documentation and news: 
 [happytransformer.com](http://happytransformer.com)**

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch>=1.0
 tqdm>=4.27
-transformers>=4.0.0
+transformers>=4.4.0
 pytest
 datasets>=1.6.0
 dataclasses; python_version<"3.7"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ readme = (current_location / "README.md").read_text()
 setup(
     name = 'happytransformer',
     packages = find_packages(),
-    version = '2.2.0',
+    version = '2.2.1',
     license='Apache 2.0',
     description = "Happy Transformer is an API built on top of Hugging Face's Transformer library that makes it easy to utilize state-of-the-art NLP models.",
     long_description= readme,
@@ -22,7 +22,7 @@ setup(
     install_requires=[
             'torch>=1.0',
             'tqdm>=4.27',
-            'transformers>=4.0.0',
+            'transformers>=4.4.0',
             'datasets>=1.6.0',
             'dataclasses; python_version < "3.7"',
             'sentencepiece',


### PR DESCRIPTION
If a transformers library version of  less than 4.4.0 is used, then an error is raised when we set the "report_to" parameter when instantiating a TrainingArguments() object. 

Also added a version badge.

Published a new version titled 2.2.1 

