### PR TITLE
Add support for bad_words Issue:#246

### DIFF
--- a/docs/pages/1-text-generation/3-settings.md
+++ b/docs/pages/1-text-generation/3-settings.md
@@ -35,6 +35,7 @@ GENSettings() contains the  fields shown in Table 1.0
 | top_k                | 50    | How many potential answers are considered when performing sampling         | 
 | top_p                | 1.0   | Min number of tokens are selected where their probabilities add up to top_p|
 | no_repeat_ngram_size | 0     | The size of an n-gram that cannot occur more than once. (0=infinity)       |
+| bad_words            | None  | List of words/phrases that cannot be generated.                            | 
 
 
 #### Examples 1.2:  
@@ -69,12 +70,17 @@ from happytransformer import HappyGeneration, GENSettings
     output_top_p_sampling = happy_gen.generate_text(
         "Artificial intelligence is ",
         args=top_p_sampling_settings)
+
+    bad_words_settings = GENSettings(do_sample=True, top_k=0, temperature = 0.7, max_length = 10, bad_words = ["new form", "social"])
+    output_bad_words = happy_gen.generate_text(
+        "Artificial intelligence is ",
+        args=bad_words_settings)
         
     print("Greedy:", output_greedy.text)  # a new field of research that has been gaining
     print("Beam:", output_beam_search.text) # one of the most promising areas of research in
     print("Generic Sampling:", output_generic_sampling.text)  #  an area of highly promising research, and a
     print("Top-k Sampling:", output_top_k_sampling.text)  # a new form of social engineering. In this
     print("Top-p Sampling:", output_top_p_sampling.text)  # a new form of social engineering. In this
-
+    print("Bad Words:", output_bad_words.text) # a technology that enables us to help people deal
 ```
 

--- a/docs/pages/1-text-generation/3-settings.md
+++ b/docs/pages/1-text-generation/3-settings.md
@@ -71,7 +71,7 @@ from happytransformer import HappyGeneration, GENSettings
         "Artificial intelligence is ",
         args=top_p_sampling_settings)
 
-    bad_words_settings = GENSettings(do_sample=True, top_k=0, temperature = 0.7, max_length = 10, bad_words = ["new form", "social"])
+    bad_words_settings = GENSettings(bad_words = ["new form", "social"])
     output_bad_words = happy_gen.generate_text(
         "Artificial intelligence is ",
         args=bad_words_settings)

--- a/examples/generation/readme_examples.py
+++ b/examples/generation/readme_examples.py
@@ -60,6 +60,17 @@ def example_1_4():
     print(result)  # EvalResult(loss=3.3437771797180176)
     print(result.loss)  # 3.3437771797180176
 
+def example_1_5():
+    happy_gen = HappyGeneration()
+    args = GENSettings(bad_words = ["new form", "social"]) # Provide a list of bad words/phrases
+    result = happy_gen.generate_text(
+        "Artificial intelligence is ",
+        args=args)
+    print(result.text)
+    
+
+
+
 
 if __name__ == "__main__":
     # example_1_0()
@@ -67,5 +78,6 @@ if __name__ == "__main__":
     example_1_2()
     # example_1_3()
     # example_1_4()
+    # example_1_5()
 
 

--- a/happytransformer/happy_generation.py
+++ b/happytransformer/happy_generation.py
@@ -28,7 +28,7 @@ class GENSettings:
     top_k: int = 50
     no_repeat_ngram_size: int = 0
     top_p: float = 1
-    bad_words: List[int] = None
+    bad_words: List[str] = None
 
 @dataclass
 class GenerationResult:
@@ -98,7 +98,7 @@ class HappyGeneration(HappyTransformer):
                                 top_k=args.top_k,
                                 no_repeat_ngram_size=args.no_repeat_ngram_size,
                                 top_p=args.top_p,
-                                bad_words_ids = bad_words_ids
+                                bad_words_ids=bad_words_ids
                                 )
         return GenerationResult(text=output[0]['generated_text'])
 

--- a/tests/test_gen.py
+++ b/tests/test_gen.py
@@ -24,6 +24,38 @@ def test_default_min_max_length():
     length = len(tokens[0])
     assert length == 5
 
+def test_bad_words():
+    
+    def robin_karp_compare(generated_tokens, bad_word_phrase):
+        """ An implementation of the Robin Karp Algorithm for efficient list comparison"""
+        generated_tokens_length = len(generated_tokens)
+        bad_word_phrase_length =  len(bad_word_phrase)
+        for i in range(0,generated_tokens_length-bad_word_phrase_length+1):
+            for j in range(0,bad_word_phrase_length):
+                if generated_tokens[i+j] != bad_word_phrase[j]:
+                    break
+            else:
+                return i # If true, return the index
+        return -1 
+
+    happy_gen = HappyGeneration()
+
+    # Test single words
+    args_test_word_single = GENSettings(bad_words=["new","tool"])
+    output_single = happy_gen.generate_text("Artificial intelligence is ", args=args_test_word_single)
+    tokens_single = happy_gen.tokenizer.encode(output_single.text, return_tensors="pt")
+    bad_words_ids_single = [happy_gen.tokenizer(" "+phrase.strip()).input_ids for phrase in args_test_word_single.bad_words]
+    for phrase in bad_words_ids_single:
+        for word_id in phrase:
+            assert word_id not in tokens_single[0]
+
+    # Test phrases 
+    args_test_word_phrase = GENSettings(bad_words=["new field"])
+    output_phrase = happy_gen.generate_text("Artificial intelligence is ", args=args_test_word_phrase)
+    tokens_phrase = happy_gen.tokenizer.encode(output_phrase.text, return_tensors="pt")
+    bad_words_ids_phrase = [happy_gen.tokenizer(" "+phrase.strip()).input_ids for phrase in args_test_word_phrase.bad_words]
+    for phrase in bad_words_ids_phrase:
+       assert robin_karp_compare(tokens_phrase[0], phrase) == -1
 
 def test_top_p():
     happy_gen = HappyGeneration()
@@ -87,7 +119,6 @@ def test_all_methods():
     print("generic-sampling: ", output_generic_sampling.text, end="\n\n")
     print("top-k-sampling: ", output_top_k_sampling.text, end="\n\n")
     print("top-p-sampling: ", output_top_p_sampling.text, end="\n\n")
-
 
 def test_gen_train_basic():
     happy_gen = HappyGeneration()

--- a/tests/test_gen.py
+++ b/tests/test_gen.py
@@ -25,37 +25,20 @@ def test_default_min_max_length():
     assert length == 5
 
 def test_bad_words():
-    
-    def robin_karp_compare(generated_tokens, bad_word_phrase):
-        """ An implementation of the Robin Karp Algorithm for efficient list comparison"""
-        generated_tokens_length = len(generated_tokens)
-        bad_word_phrase_length =  len(bad_word_phrase)
-        for i in range(0,generated_tokens_length-bad_word_phrase_length+1):
-            for j in range(0,bad_word_phrase_length):
-                if generated_tokens[i+j] != bad_word_phrase[j]:
-                    break
-            else:
-                return i # If true, return the index
-        return -1 
-
     happy_gen = HappyGeneration()
-
     # Test single words
     args_test_word_single = GENSettings(bad_words=["new","tool"])
     output_single = happy_gen.generate_text("Artificial intelligence is ", args=args_test_word_single)
-    tokens_single = happy_gen.tokenizer.encode(output_single.text, return_tensors="pt")
-    bad_words_ids_single = [happy_gen.tokenizer(" "+phrase.strip()).input_ids for phrase in args_test_word_single.bad_words]
-    for phrase in bad_words_ids_single:
-        for word_id in phrase:
-            assert word_id not in tokens_single[0]
-
+    output_words_single = output_single.text.split()
+    for phrase in args_test_word_single.bad_words:
+        for word in phrase.split():
+            assert word not in output_words_single
     # Test phrases 
     args_test_word_phrase = GENSettings(bad_words=["new field"])
     output_phrase = happy_gen.generate_text("Artificial intelligence is ", args=args_test_word_phrase)
-    tokens_phrase = happy_gen.tokenizer.encode(output_phrase.text, return_tensors="pt")
-    bad_words_ids_phrase = [happy_gen.tokenizer(" "+phrase.strip()).input_ids for phrase in args_test_word_phrase.bad_words]
-    for phrase in bad_words_ids_phrase:
-       assert robin_karp_compare(tokens_phrase[0], phrase) == -1
+    for phrase in args_test_word_phrase.bad_words:
+        assert phrase not in output_phrase.text
+
 
 def test_top_p():
     happy_gen = HappyGeneration()


### PR DESCRIPTION
 Added support for bad_word_ids as discussed in Issue#246 
- Modified GENSettings to allow users to provide a list of bad words/phrases
- Modified generate_text in `happy-transformer/happy_generation.py` 
- Added a test_case `test_bad_words` in `tests/test_gen.py`
- Updated documentation and examples  in `docs/1-text-generation/3-settings.md`