### PR TITLE
add encoding params(defaut set to utf-8) for train

### DIFF
--- a/happytransformer/qa/trainer.py
+++ b/happytransformer/qa/trainer.py
@@ -55,7 +55,7 @@ class QATrainer(HappyTrainer):
     Trainer class for HappyTextClassification
     """
 
-    def train(self, input_filepath, dataclass_args: QATrainArgs):
+    def train(self, input_filepath, dataclass_args: QATrainArgs, encoding="utf-8"):
         """
         See docstring in HappyQuestionAnswering.train()
         """
@@ -69,7 +69,7 @@ class QATrainer(HappyTrainer):
                              "It will be added soon. ")
 
         self.logger.info("Preprocessing dataset...")
-        contexts, questions, answers = self._get_data(input_filepath)
+        contexts, questions, answers = self._get_data(input_filepath, encoding=encoding)
         self.__add_end_idx(contexts, answers)
         encodings = self.tokenizer(contexts, questions, truncation=True, padding=True)
         self.__add_token_positions(encodings, answers)
@@ -77,7 +77,7 @@ class QATrainer(HappyTrainer):
         data_collator = DataCollatorWithPadding(self.tokenizer)
         self._run_train(dataset, dataclass_args, data_collator)
 
-    def eval(self, input_filepath, dataclass_args: QAEvalArgs):
+    def eval(self, input_filepath, dataclass_args: QAEvalArgs, encoding="utf-8"):
         """
         See docstring in HappyQuestionAnswering.eval()
 
@@ -91,7 +91,7 @@ class QATrainer(HappyTrainer):
                              "not available for question answering models. "
                              "It will be added soon. ")
 
-        contexts, questions, answers = self._get_data(input_filepath)
+        contexts, questions, answers = self._get_data(input_filepath, encoding=encoding)
 
         self.__add_end_idx(contexts, answers)
         encodings = self.tokenizer(contexts, questions, truncation=True, padding=True)
@@ -103,7 +103,7 @@ class QATrainer(HappyTrainer):
         return EvalResult(loss=result["eval_loss"])
 
 
-    def test(self, input_filepath, solve, dataclass_args: QATestArgs):
+    def test(self, input_filepath, solve, dataclass_args: QATestArgs, encoding="utf-8"):
         """
         See docstring in HappyQuestionAnswering.test()
 
@@ -118,7 +118,7 @@ class QATrainer(HappyTrainer):
                              "not available for question answering models. "
                              "It will be added soon. ")
 
-        contexts, questions = self._get_data(input_filepath, test_data=True)
+        contexts, questions = self._get_data(input_filepath, test_data=True, encoding=encoding)
 
         return [
             solve(context, question)[0]
@@ -127,7 +127,7 @@ class QATrainer(HappyTrainer):
         ]
 
     @staticmethod
-    def _get_data(filepath, test_data=False):
+    def _get_data(filepath, encoding, test_data=False):
         """
         Used to collect
         :param filepath: a string that contains the location of the data
@@ -137,7 +137,7 @@ class QATrainer(HappyTrainer):
         contexts = []
         questions = []
         answers = []
-        with open(filepath, newline='') as csv_file:
+        with open(filepath, newline='', encoding=encoding) as csv_file:
             reader = csv.DictReader(csv_file)
             for row in reader:
                 contexts.append(row['context'])

--- a/happytransformer/tc/trainer.py
+++ b/happytransformer/tc/trainer.py
@@ -54,7 +54,9 @@ class TCTrainer(HappyTrainer):
     """
 
     def train(self, input_filepath, dataclass_args: TCTrainArgs, encoding="utf-8"):
-
+        """
+        :param encoding: name of the encoding used to decode the file
+        """
         if not dataclass_args.load_preprocessed_data:
             self.logger.info("Preprocessing dataset...")
             contexts, labels = self._get_data(input_filepath, encoding=encoding)
@@ -73,10 +75,10 @@ class TCTrainer(HappyTrainer):
         data_collator = DataCollatorWithPadding(self.tokenizer)
         self._run_train(train_dataset, dataclass_args, data_collator)
 
-    def eval(self, input_filepath, dataclass_args: TCEvalArgs):
+    def eval(self, input_filepath, dataclass_args: TCEvalArgs, encoding="utf-8"):
         if not dataclass_args.load_preprocessed_data:
             self.logger.info("Preprocessing dataset...")
-            contexts, labels = self._get_data(input_filepath)
+            contexts, labels = self._get_data(input_filepath, encoding=encoding)
             eval_encodings = self.tokenizer(contexts, truncation=True, padding=True)
         else:
             self.logger.info("Loading dataset from %s...", dataclass_args.load_preprocessed_data_path)
@@ -95,12 +97,12 @@ class TCTrainer(HappyTrainer):
         result = self._run_eval(eval_dataset, data_collator, dataclass_args)
         return EvalResult(loss=result["eval_loss"])
 
-    def test(self, input_filepath, solve, dataclass_args: TCTestArgs):
+    def test(self, input_filepath, solve, dataclass_args: TCTestArgs, encoding="utf-8"):
         """
         See docstring in HappyQuestionAnswering.test()
         solve: HappyQuestionAnswering.answers_to_question()
         """
-        contexts = self._get_data(input_filepath, test_data=True)
+        contexts = self._get_data(input_filepath, test_data=True, encoding=encoding)
 
         return [
             solve(context)

--- a/happytransformer/tc/trainer.py
+++ b/happytransformer/tc/trainer.py
@@ -53,11 +53,11 @@ class TCTrainer(HappyTrainer):
     A class for training text classification functionality
     """
 
-    def train(self, input_filepath, dataclass_args: TCTrainArgs):
+    def train(self, input_filepath, dataclass_args: TCTrainArgs, encoding="utf-8"):
 
         if not dataclass_args.load_preprocessed_data:
             self.logger.info("Preprocessing dataset...")
-            contexts, labels = self._get_data(input_filepath)
+            contexts, labels = self._get_data(input_filepath, encoding=encoding)
             train_encodings = self.tokenizer(contexts, truncation=True, padding=True)
         else:
             self.logger.info("Loading dataset from %s...", dataclass_args.load_preprocessed_data_path)
@@ -108,7 +108,7 @@ class TCTrainer(HappyTrainer):
         ]
 
     @staticmethod
-    def _get_data(filepath, test_data=False):
+    def _get_data(filepath, encoding, test_data=False):
         """
         Used for parsing data for training and evaluating (both contain labels)
         :param filepath: a string that contains the location of the data
@@ -116,7 +116,7 @@ class TCTrainer(HappyTrainer):
         """
         contexts = []
         labels = []
-        with open(filepath, newline='') as csv_file:
+        with open(filepath, newline='', encoding=encoding) as csv_file:
             reader = csv.DictReader(csv_file)
             for row in reader:
                 contexts.append(row['text'])


### PR DESCRIPTION
The initial `_get_data` function in `trainer.py` opens file without setting encoding,  which may lead to a codec error.