### PR TITLE
Add ability to use models from private repositories

### DIFF
--- a/docs/pages/1-text-generation/1-instantiation.md
+++ b/docs/pages/1-text-generation/1-instantiation.md
@@ -14,6 +14,8 @@ Initialize a HappyTextGeneration() object to perform text generation
  1. model_type (string): Specify the model name in all caps, such as "ROBERTA" or "ALBERT" 
  2. model_name(string): below is a URL that contains potential models: 
        [MODELS](https://huggingface.co/models?pipeline_tag=text-generation)
+ 3. use_auth_token (string): Specify the authentication token to 
+    [load private](https://huggingface.co/transformers/model_sharing.html) models. 
  
 
 We recommend using "HappyTextGeneration("GPT2", "gpt2-xl")" for the best performance. 
@@ -28,6 +30,7 @@ from happytransformer import HappyGeneration
 happy_gen = HappyGeneration("GPT2", "gpt2")  # default
 # happy_gen = HappyGeneration("GPT2", "gpt2-large")  # Good for Google Colab
 # happy_gen = HappyGeneration("GPT2", "gpt2-xl")  # Best performance 
+# happy_gen_private = HappyGeneration("GPT2", "user-repo/gpt2", use_auth_token="123abc")
 
 ```
 

--- a/docs/pages/2-text-classification/1-instantiation.md
+++ b/docs/pages/2-text-classification/1-instantiation.md
@@ -18,8 +18,10 @@ detect if an email is spam based on its text.
 1. model_type (string):  specify the model name in all caps, such as "ROBERTA" or "ALBERT"
 2. model_name(string): below is a URL that contains potential models. The default is "distilbert-base-uncased"
        [MODELS](https://huggingface.co/models?filter=text-classification)
-3. num_labels(int): The number of text categories. The default is 2
-    
+3. num_labels(int): The number of text categories. The default is 2 
+4. use_auth_token (string): Specify the authentication token to 
+   [load private](https://huggingface.co/transformers/model_sharing.html) models. 
+
 WARNING: If you try to load a pretrained model that has a different number of categories 
 than num_labels, then you will get an error 
 
@@ -35,6 +37,7 @@ happy_tc_distilbert = HappyTextClassification("DISTILBERT", "distilbert-base-unc
 happy_tc_albert = HappyTextClassification(model_type="ALBERT", model_name="albert-base-v2")
 happy_tc_bert = HappyTextClassification("BERT", "bert-base-uncased")
 happy_tc_roberta = HappyTextClassification("ROBERTA", "roberta-base")
+happy_tc_private_roberta = HappyTextClassification("ROBERTA", "user-repo/roberta-base", use_auth_token="123abc")
 
 ```
 

--- a/docs/pages/3-question-answering/1-instantiation.md
+++ b/docs/pages/3-question-answering/1-instantiation.md
@@ -18,7 +18,8 @@ The outputted answer is always a text-span with the provided information.
 1. model_type (string): specify the model name in all caps, such as "ROBERTA" or "ALBERT"
 2. model_name(string): below is a URL that contains potential models. 
    [MODELS](https://huggingface.co/models?filter=question-answering)
-
+3. use_auth_token (string): Specify the authentication token to 
+   [load private](https://huggingface.co/transformers/model_sharing.html) models. 
 
 We recommend using "HappyQuestionAnswering("ALBERT", "mfeb/albert-xxlarge-v2-squad2")" for the best performance 
 
@@ -32,5 +33,6 @@ happy_qa_albert = HappyQuestionAnswering("ALBERT", "mfeb/albert-xxlarge-v2-squad
 # good model when using with limited hardware 
 happy_qa_bert = HappyQuestionAnswering("BERT", "mrm8488/bert-tiny-5-finetuned-squadv2")
 happy_qa_roberta = HappyQuestionAnswering("ROBERTA", "deepset/roberta-base-squad2")
+happy_qa__private_roberta = HappyQuestionAnswering("ROBERTA", "user-repo/roberta-base-squad2", use_auth_token="123abc")
 
 ```

--- a/docs/pages/4-word-prediction/1-instantiation.md
+++ b/docs/pages/4-word-prediction/1-instantiation.md
@@ -17,7 +17,8 @@ Initialize a HappyWordPrediction object to perform word prediction.
  1. model_type (string): Specify the model name in all caps, such as "ROBERTA" or "ALBERT" 
  2. model_name(string): below is a URL that contains potential models: 
        [MODELS](https://huggingface.co/models?filter=masked-lm)
- 
+ 3. use_auth_token (string): Specify the authentication token to 
+       [load private](https://huggingface.co/transformers/model_sharing.html) models. 
 
 Note: For all Transformers, the masked token is **"[MASK]"**
 
@@ -32,6 +33,7 @@ happy_wp_distilbert = HappyWordPrediction("DISTILBERT", "distilbert-base-uncased
 happy_wp_albert = HappyWordPrediction("ALBERT", "albert-base-v2")
 happy_wp_bert = HappyWordPrediction("BERT", "bert-base-uncased")
 happy_wp_roberta = HappyWordPrediction("ROBERTA", "roberta-base")
+happy_wp_private_roberta = HappyWordPrediction("ROBERTA", "user-repo/roberta-base", use_auth_token="123abc")
 
 ```
 ## Tutorials 

--- a/docs/pages/5-token-classification/1-instantiation.md
+++ b/docs/pages/5-token-classification/1-instantiation.md
@@ -11,8 +11,9 @@ Initialize a HappyTokenClassification() object for token classification
 
 **Initialization Arguments:**
  1. model_type (string): specify the model name in all caps, such as "ROBERTA" or "ALBERT"
- 2. model_name(string): potential models can be found [here](https://huggingface.co/models?pipeline_tag=token-classification)
- 
+ 2. model_name(string): potential models can be found [here](https://huggingface.co/models?pipeline_tag=token-classification) 
+ 3. use_auth_token (string): Specify the authentication token to 
+       [load private](https://huggingface.co/transformers/model_sharing.html) models. 
 
 #### Example 5.0:
 ```python
@@ -20,4 +21,5 @@ from happytransformer import HappyTokenClassification
 # --------------------------------------#
 happy_toc = HappyTokenClassification("BERT", "dslim/bert-base-NER")  # default 
 happy_toc_large = HappyTokenClassification("XLM-ROBERTA", "xlm-roberta-large-finetuned-conll03-english") 
+happy_toc_private = HappyTokenClassification("BERT", "user-repo/bert-base-NER", use_auth_token="123abc")
 ```

--- a/docs/pages/6-next-sentence/1-instantiation.md
+++ b/docs/pages/6-next-sentence/1-instantiation.md
@@ -14,8 +14,9 @@ Initialize a HappyNextSentence() object to next sentence prediction
 **Initialization Arguments:**
  1. model_type (string): The default is "BERT", which is currently the only available model 
  2. model_name(string): We recommend  BERT models like 
- "bert-base-uncased" and "bert-large-uncased" that have not been finetuned 
- 
+ "bert-base-uncased" and "bert-large-uncased" that have not been finetuned  
+ 3. use_auth_token (string): Specify the authentication token to 
+       [load private](https://huggingface.co/transformers/model_sharing.html) models. 
 
 #### Example 6.0:
 ```python
@@ -23,5 +24,5 @@ from happytransformer import HappyNextSentence
 # --------------------------------------#
 happy_ns = HappyNextSentence("BERT", "bert-base-uncased")  # default 
 happy_ns_large = HappyNextSentence("BERT", "bert-large-uncased") 
-
+happy_ns_private = HappyNextSentence("BERT", "user-repo/bert-base-uncased", use_auth_token="123abc")
 ```

--- a/docs/pages/7-text-to-text/1-instantiation.md
+++ b/docs/pages/7-text-to-text/1-instantiation.md
@@ -14,6 +14,8 @@ Initialize a HappyTextToText() object to perform text-to-text generation
  1. model_type (string): Specify the model name in all caps, such as "T5" or "BART" 
  2. model_name(string): below are  URLs that contains potential models: 
        [standard models](https://huggingface.co/models?pipeline_tag=text2text-generation) and [translation models](https://huggingface.co/models?pipeline_tag=translation)
+ 3. use_auth_token (string): Specify the authentication token to 
+       [load private](https://huggingface.co/transformers/model_sharing.html) models. 
 
 
 #### Example 7.0:
@@ -21,5 +23,6 @@ Initialize a HappyTextToText() object to perform text-to-text generation
 from happytransformer import HappyTextToText
 # --------------------------------------#
 happy_tt = HappyTextToText("T5", "t5-small")  # default
+happy_tt_private = HappyTextToText("T5", "user-repo/t5-small", use_auth_token="123abc")  # default
 
 ```

--- a/happytransformer/happy_generation.py
+++ b/happytransformer/happy_generation.py
@@ -44,14 +44,15 @@ class HappyGeneration(HappyTransformer):
     to understand and to offload complex tasks to
     other classes.
     """
-    def __init__(self, model_type: str = "GPT2", model_name: str = "gpt2", load_path: str = ""):
+    def __init__(self, model_type: str = "GPT2", model_name: str = "gpt2", 
+                 load_path: str = "", use_auth_token: str = None):
 
         self.adaptor = get_adaptor(model_type)
 
         if load_path != "":
             model = AutoModelForCausalLM.from_pretrained(load_path)
         else:
-            model = AutoModelForCausalLM.from_pretrained(model_name)
+            model = AutoModelForCausalLM.from_pretrained(model_name, use_auth_token=use_auth_token)
 
         super().__init__(model_type, model_name, model)
         device_number = detect_cuda_device_number()

--- a/happytransformer/happy_next_sentence.py
+++ b/happytransformer/happy_next_sentence.py
@@ -9,13 +9,15 @@ class HappyNextSentence(HappyTransformer):
     A user facing class for next sentence prediction
     """
     def __init__(self, model_type="BERT",
-                 model_name="bert-base-uncased", load_path: str = ""):
+                 model_name="bert-base-uncased", 
+                 load_path: str = "", 
+                 use_auth_token: str = None):
 
         self.adaptor = get_adaptor(model_type)
         if load_path != "":
             model = AutoModelForNextSentencePrediction.from_pretrained(load_path)
         else:
-            model = AutoModelForNextSentencePrediction.from_pretrained(model_name)
+            model = AutoModelForNextSentencePrediction.from_pretrained(model_name, use_auth_token=use_auth_token)
 
         super().__init__(model_type, model_name, model)
         self._pipeline = None

--- a/happytransformer/happy_question_answering.py
+++ b/happytransformer/happy_question_answering.py
@@ -34,14 +34,16 @@ class HappyQuestionAnswering(HappyTransformer):
     other classes.
     """
     def __init__(self, model_type="DISTILBERT",
-                 model_name="distilbert-base-cased-distilled-squad", load_path: str = ""):
+                 model_name="distilbert-base-cased-distilled-squad", 
+                 load_path: str = ""
+                 use_auth_token: str = None):
         
         self.adaptor = get_adaptor(model_type)
 
         if load_path != "":
             model = AutoModelForQuestionAnswering.from_pretrained(load_path)
         else:
-            model = AutoModelForQuestionAnswering.from_pretrained(model_name)
+            model = AutoModelForQuestionAnswering.from_pretrained(model_name, use_auth_token=use_auth_token)
 
         super().__init__(model_type, model_name, model)
         device_number = detect_cuda_device_number()

--- a/happytransformer/happy_question_answering.py
+++ b/happytransformer/happy_question_answering.py
@@ -35,7 +35,7 @@ class HappyQuestionAnswering(HappyTransformer):
     """
     def __init__(self, model_type="DISTILBERT",
                  model_name="distilbert-base-cased-distilled-squad", 
-                 load_path: str = ""
+                 load_path: str = "",
                  use_auth_token: str = None):
         
         self.adaptor = get_adaptor(model_type)

--- a/happytransformer/happy_text_classification.py
+++ b/happytransformer/happy_text_classification.py
@@ -25,7 +25,7 @@ class HappyTextClassification(HappyTransformer):
     """
 
     def __init__(self, model_type="DISTILBERT",
-                 model_name="distilbert-base-uncased", num_labels: int = 2, load_path: str = ""):
+                 model_name="distilbert-base-uncased", num_labels: int = 2, load_path: str = "", use_auth_token: str = None):
         self.adaptor = get_adaptor(model_type)
 
         config = AutoConfig.from_pretrained(model_name, num_labels=num_labels)
@@ -33,7 +33,7 @@ class HappyTextClassification(HappyTransformer):
         if load_path != "":
             model = AutoModelForSequenceClassification.from_pretrained(load_path, config=config)
         else:
-            model = AutoModelForSequenceClassification.from_pretrained(model_name, config=config)
+            model = AutoModelForSequenceClassification.from_pretrained(model_name, config=config, use_auth_token=use_auth_token)
 
 
         super().__init__(model_type, model_name, model)

--- a/happytransformer/happy_text_to_text.py
+++ b/happytransformer/happy_text_to_text.py
@@ -41,14 +41,14 @@ class HappyTextToText(HappyTransformer):
     """
     A user facing class for text to text generation
     """
-    def __init__(self, model_type: str = "T5", model_name: str = "t5-small", load_path: str = ""):
+    def __init__(self, model_type: str = "T5", model_name: str = "t5-small", load_path: str = "", use_auth_token: str = None):
 
         self.adaptor = get_adaptor(model_type)
 
         if load_path != "":
             model = AutoModelForSeq2SeqLM.from_pretrained(load_path)
         else:
-            model = AutoModelForSeq2SeqLM.from_pretrained(model_name)
+            model = AutoModelForSeq2SeqLM.from_pretrained(model_name, use_auth_token=use_auth_token)
 
 
         super().__init__(model_type, model_name, model)

--- a/happytransformer/happy_token_classification.py
+++ b/happytransformer/happy_token_classification.py
@@ -25,14 +25,14 @@ class HappyTokenClassification(HappyTransformer):
     A user facing class for token classification
     """
     def __init__(
-        self, model_type: str = "BERT", model_name: str = "dslim/bert-base-NER", load_path: str = ""):
+        self, model_type: str = "BERT", model_name: str = "dslim/bert-base-NER", load_path: str = "", use_auth_token: str = None):
 
         self.adaptor = get_adaptor(model_type)
 
         if load_path != "":
             model = AutoModelForTokenClassification.from_pretrained(load_path)
         else:
-            model = AutoModelForTokenClassification.from_pretrained(model_name)
+            model = AutoModelForTokenClassification.from_pretrained(model_name, use_auth_token=use_auth_token)
 
 
         super().__init__(model_type, model_name, model)

--- a/happytransformer/happy_transformer.py
+++ b/happytransformer/happy_transformer.py
@@ -15,14 +15,14 @@ class HappyTransformer():
 
     """
 
-    def __init__(self, model_type, model_name, model, load_path=""):
+    def __init__(self, model_type, model_name, model, load_path="", use_auth_token: str = None):
         self.model_type = model_type  # BERT, #DISTILBERT, ROBERTA, ALBERT etc
         self.model_name = model_name
 
         if load_path != "":
             self.tokenizer = AutoTokenizer.from_pretrained(load_path)
         else:
-            self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+            self.tokenizer = AutoTokenizer.from_pretrained(model_name, use_auth_token=use_auth_token)
         self.model = model
         self.model.eval()
         self._trainer = None  # initialized in child class

--- a/happytransformer/happy_word_prediction.py
+++ b/happytransformer/happy_word_prediction.py
@@ -22,7 +22,7 @@ class HappyWordPrediction(HappyTransformer):
     """
     def __init__(
             self, model_type: str = "DISTILBERT", model_name: str = "distilbert-base-uncased",
-            load_path: str =""):
+            load_path: str ="", use_auth_token: str = None):
 
 
         self.adaptor = get_adaptor(model_type)
@@ -30,7 +30,7 @@ class HappyWordPrediction(HappyTransformer):
         if load_path != "":
             model = AutoModelForMaskedLM.from_pretrained(load_path)
         else:
-            model = AutoModelForMaskedLM.from_pretrained(model_name)
+            model = AutoModelForMaskedLM.from_pretrained(model_name, use_auth_token=use_auth_token)
 
         super().__init__(model_type, model_name, model, load_path=load_path)
 


### PR DESCRIPTION
## Introduction 🤞

Big fan of HappyTransformer, but I've noticed that we're lacking the ability to use private repositories. This pull-request implements the `use_auth_token` which we use in our fork. 

I was considering simply adding a reference to `**kwargs` and pass that to the `from_pretrained(...)` calls but decided against it. 

## Documentation 📘

Every model's documentation has been updated to reflect the new API capability. 

## Backwards Compatibility 👀

The does not break API backwards compatibility 🙏

## Further Discussions 💬

One thing I've noticed missing from HF is using an environment variable to pass the auth token instead of having it explicitly defined as part of the model calls. 

This is something I'd like to explore and figure out if it's any interest to you. If so I'll take a stab. 🤷‍♂️