### PR TITLE
Problem with 2.3.2 — Fix to use_auth_token

### DIFF
--- a/happytransformer/happy_generation.py
+++ b/happytransformer/happy_generation.py
@@ -54,7 +54,7 @@ class HappyGeneration(HappyTransformer):
         else:
             model = AutoModelForCausalLM.from_pretrained(model_name, use_auth_token=use_auth_token)
 
-        super().__init__(model_type, model_name, model)
+        super().__init__(model_type, model_name, model, use_auth_token=use_auth_token)
         device_number = detect_cuda_device_number()
 
         self._pipeline = TextGenerationPipeline(model=self.model, tokenizer=self.tokenizer, device=device_number)

--- a/happytransformer/happy_next_sentence.py
+++ b/happytransformer/happy_next_sentence.py
@@ -19,7 +19,7 @@ class HappyNextSentence(HappyTransformer):
         else:
             model = AutoModelForNextSentencePrediction.from_pretrained(model_name, use_auth_token=use_auth_token)
 
-        super().__init__(model_type, model_name, model)
+        super().__init__(model_type, model_name, model, use_auth_token=use_auth_token)
         self._pipeline = None
         self._trainer = None
 

--- a/happytransformer/happy_question_answering.py
+++ b/happytransformer/happy_question_answering.py
@@ -45,7 +45,7 @@ class HappyQuestionAnswering(HappyTransformer):
         else:
             model = AutoModelForQuestionAnswering.from_pretrained(model_name, use_auth_token=use_auth_token)
 
-        super().__init__(model_type, model_name, model)
+        super().__init__(model_type, model_name, model, use_auth_token=use_auth_token)
         device_number = detect_cuda_device_number()
 
         self._pipeline = QuestionAnsweringPipeline(model=self.model, tokenizer=self.tokenizer, device=device_number)

--- a/happytransformer/happy_text_classification.py
+++ b/happytransformer/happy_text_classification.py
@@ -36,7 +36,7 @@ class HappyTextClassification(HappyTransformer):
             model = AutoModelForSequenceClassification.from_pretrained(model_name, config=config, use_auth_token=use_auth_token)
 
 
-        super().__init__(model_type, model_name, model)
+        super().__init__(model_type, model_name, model, use_auth_token=use_auth_token)
 
         device_number = detect_cuda_device_number()
         self._pipeline = TextClassificationPipeline(

--- a/happytransformer/happy_text_to_text.py
+++ b/happytransformer/happy_text_to_text.py
@@ -51,7 +51,7 @@ class HappyTextToText(HappyTransformer):
             model = AutoModelForSeq2SeqLM.from_pretrained(model_name, use_auth_token=use_auth_token)
 
 
-        super().__init__(model_type, model_name, model)
+        super().__init__(model_type, model_name, model, use_auth_token=use_auth_token)
 
         device_number = detect_cuda_device_number()
 

--- a/happytransformer/happy_token_classification.py
+++ b/happytransformer/happy_token_classification.py
@@ -35,7 +35,7 @@ class HappyTokenClassification(HappyTransformer):
             model = AutoModelForTokenClassification.from_pretrained(model_name, use_auth_token=use_auth_token)
 
 
-        super().__init__(model_type, model_name, model)
+        super().__init__(model_type, model_name, model, use_auth_token=use_auth_token)
 
         device_number = detect_cuda_device_number()
 

--- a/happytransformer/happy_word_prediction.py
+++ b/happytransformer/happy_word_prediction.py
@@ -32,7 +32,7 @@ class HappyWordPrediction(HappyTransformer):
         else:
             model = AutoModelForMaskedLM.from_pretrained(model_name, use_auth_token=use_auth_token)
 
-        super().__init__(model_type, model_name, model, load_path=load_path)
+        super().__init__(model_type, model_name, model, load_path=load_path, use_auth_token=use_auth_token)
 
         device_number = detect_cuda_device_number()
 


### PR DESCRIPTION
Apologies, this is in relation to #266 and #267 — 

As it stands the release isn't broken, but the `use_auth_token` isn't being used correctly because I forgot to also include it in the `super().__init__(..., use_auth_token=use_auth_token)`.

This PR rectifies this but will require a new release. 

Apologies for this!
