### PR TITLE
Standardize Encoding Format 

### DIFF
--- a/happytransformer/gen/default_args.py
+++ b/happytransformer/gen/default_args.py
@@ -13,6 +13,8 @@ ARGS_GEN_TRAIN = {
     'load_preprocessed_data_path': "",
     'preprocessing_processes': 1,
     'mlm_probability': 0.15,
+    'encoding': "utf-8"
+
 }
 
 
@@ -24,6 +26,7 @@ ARGS_GEN_EVAl = {
     'load_preprocessed_data_path': "",
     'preprocessing_processes': 1,
     'mlm_probability': 0.15,
+    'encoding': "utf-8"
 
 }
 
@@ -33,5 +36,6 @@ ARGS_GEN_TEST = {
     'save_preprocessed_data_path': "",
     'load_preprocessed_data': False,
     'load_preprocessed_data_path': "",
+    'encoding': "utf-8"
 
 }

--- a/happytransformer/gen/default_args.py
+++ b/happytransformer/gen/default_args.py
@@ -13,7 +13,6 @@ ARGS_GEN_TRAIN = {
     'load_preprocessed_data_path': "",
     'preprocessing_processes': 1,
     'mlm_probability': 0.15,
-    'encoding': "utf-8"
 
 }
 
@@ -26,7 +25,6 @@ ARGS_GEN_EVAl = {
     'load_preprocessed_data_path': "",
     'preprocessing_processes': 1,
     'mlm_probability': 0.15,
-    'encoding': "utf-8"
 
 }
 
@@ -36,6 +34,5 @@ ARGS_GEN_TEST = {
     'save_preprocessed_data_path': "",
     'load_preprocessed_data': False,
     'load_preprocessed_data_path': "",
-    'encoding': "utf-8"
 
 }

--- a/happytransformer/gen/default_args.py
+++ b/happytransformer/gen/default_args.py
@@ -13,7 +13,6 @@ ARGS_GEN_TRAIN = {
     'load_preprocessed_data_path': "",
     'preprocessing_processes': 1,
     'mlm_probability': 0.15,
-
 }
 
 
@@ -25,7 +24,6 @@ ARGS_GEN_EVAl = {
     'load_preprocessed_data_path': "",
     'preprocessing_processes': 1,
     'mlm_probability': 0.15,
-
 }
 
 
@@ -34,5 +32,4 @@ ARGS_GEN_TEST = {
     'save_preprocessed_data_path': "",
     'load_preprocessed_data': False,
     'load_preprocessed_data_path': "",
-
 }

--- a/happytransformer/happy_trainer.py
+++ b/happytransformer/happy_trainer.py
@@ -45,11 +45,10 @@ class HappyTrainer:
         raise NotImplementedError()
 
     @staticmethod
-    def _get_data(filepath, encoding="utf-8", test_data=False):
+    def _get_data(filepath, test_data=False):
         """
 
         :param filepath:  A string to file location
-        :param encoding: Encoding format
         :param test_data: False for train and eval, True for test
         :return: varies for each task
         """

--- a/happytransformer/happy_trainer.py
+++ b/happytransformer/happy_trainer.py
@@ -45,10 +45,11 @@ class HappyTrainer:
         raise NotImplementedError()
 
     @staticmethod
-    def _get_data(filepath, test_data=False):
+    def _get_data(filepath, encoding="utf-8", test_data=False):
         """
 
         :param filepath:  A string to file location
+        :param encoding: Encoding format
         :param test_data: False for train and eval, True for test
         :return: varies for each task
         """

--- a/happytransformer/qa/default_args.py
+++ b/happytransformer/qa/default_args.py
@@ -11,6 +11,8 @@ ARGS_QA_TRAIN = {
     'save_preprocessed_data_path': "",
     'load_preprocessed_data': False,
     'load_preprocessed_data_path': "",
+    'encoding': "utf-8"
+
 }
 
 
@@ -20,6 +22,7 @@ ARGS_QA_EVAl = {
     'load_preprocessed_data': False,
     'load_preprocessed_data_path': "",
     'batch_size': 1,
+    'encoding': "utf-8"
 
 }
 
@@ -28,4 +31,6 @@ ARGS_QA_TEST = {
     'save_preprocessed_data_path': "",
     'load_preprocessed_data': False,
     'load_preprocessed_data_path': "",
+    'encoding': "utf-8"
+
 }

--- a/happytransformer/qa/default_args.py
+++ b/happytransformer/qa/default_args.py
@@ -11,7 +11,6 @@ ARGS_QA_TRAIN = {
     'save_preprocessed_data_path': "",
     'load_preprocessed_data': False,
     'load_preprocessed_data_path': "",
-    'encoding': "utf-8"
 
 }
 
@@ -22,7 +21,6 @@ ARGS_QA_EVAl = {
     'load_preprocessed_data': False,
     'load_preprocessed_data_path': "",
     'batch_size': 1,
-    'encoding': "utf-8"
 
 }
 
@@ -31,6 +29,5 @@ ARGS_QA_TEST = {
     'save_preprocessed_data_path': "",
     'load_preprocessed_data': False,
     'load_preprocessed_data_path': "",
-    'encoding': "utf-8"
 
 }

--- a/happytransformer/qa/default_args.py
+++ b/happytransformer/qa/default_args.py
@@ -11,7 +11,6 @@ ARGS_QA_TRAIN = {
     'save_preprocessed_data_path': "",
     'load_preprocessed_data': False,
     'load_preprocessed_data_path': "",
-
 }
 
 
@@ -21,7 +20,6 @@ ARGS_QA_EVAl = {
     'load_preprocessed_data': False,
     'load_preprocessed_data_path': "",
     'batch_size': 1,
-
 }
 
 ARGS_QA_TEST = {
@@ -29,5 +27,4 @@ ARGS_QA_TEST = {
     'save_preprocessed_data_path': "",
     'load_preprocessed_data': False,
     'load_preprocessed_data_path': "",
-
 }

--- a/happytransformer/qa/trainer.py
+++ b/happytransformer/qa/trainer.py
@@ -31,7 +31,6 @@ class QATrainArgs:
     load_preprocessed_data: bool = ARGS_QA_TRAIN["load_preprocessed_data"]
     load_preprocessed_data_path: str = ARGS_QA_TRAIN["load_preprocessed_data_path"]
     batch_size: int = ARGS_QA_TRAIN["batch_size"]
-    encoding: str = ARGS_QA_TRAIN["encoding"]
 
 
 @dataclass
@@ -41,7 +40,6 @@ class QAEvalArgs:
     save_preprocessed_data_path: str = ARGS_QA_EVAl["save_preprocessed_data_path"]
     load_preprocessed_data: bool = ARGS_QA_EVAl["load_preprocessed_data"]
     load_preprocessed_data_path: str = ARGS_QA_EVAl["load_preprocessed_data_path"]
-    encoding: str = ARGS_QA_EVAl["encoding"]
 
 
 @dataclass
@@ -50,7 +48,6 @@ class QATestArgs:
     save_preprocessed_data_path: str = ARGS_QA_TEST["save_preprocessed_data_path"]
     load_preprocessed_data: bool = ARGS_QA_TEST["load_preprocessed_data"]
     load_preprocessed_data_path: str = ARGS_QA_TEST["load_preprocessed_data_path"]
-    encoding: str = ARGS_QA_TEST["encoding"]
 
 
 class QATrainer(HappyTrainer):
@@ -58,7 +55,7 @@ class QATrainer(HappyTrainer):
     Trainer class for HappyTextClassification
     """
 
-    def train(self, input_filepath, dataclass_args: QATrainArgs, encoding="utf-8"):
+    def train(self, input_filepath, dataclass_args: QATrainArgs):
         """
         See docstring in HappyQuestionAnswering.train()
         """
@@ -72,7 +69,7 @@ class QATrainer(HappyTrainer):
                              "It will be added soon. ")
 
         self.logger.info("Preprocessing dataset...")
-        contexts, questions, answers = self._get_data(input_filepath, encoding=encoding)
+        contexts, questions, answers = self._get_data(input_filepath)
         self.__add_end_idx(contexts, answers)
         encodings = self.tokenizer(contexts, questions, truncation=True, padding=True)
         self.__add_token_positions(encodings, answers)
@@ -80,7 +77,7 @@ class QATrainer(HappyTrainer):
         data_collator = DataCollatorWithPadding(self.tokenizer)
         self._run_train(dataset, dataclass_args, data_collator)
 
-    def eval(self, input_filepath, dataclass_args: QAEvalArgs, encoding="utf-8"):
+    def eval(self, input_filepath, dataclass_args: QAEvalArgs):
         """
         See docstring in HappyQuestionAnswering.eval()
 
@@ -94,7 +91,7 @@ class QATrainer(HappyTrainer):
                              "not available for question answering models. "
                              "It will be added soon. ")
 
-        contexts, questions, answers = self._get_data(input_filepath, encoding=encoding)
+        contexts, questions, answers = self._get_data(input_filepath)
 
         self.__add_end_idx(contexts, answers)
         encodings = self.tokenizer(contexts, questions, truncation=True, padding=True)
@@ -106,7 +103,7 @@ class QATrainer(HappyTrainer):
         return EvalResult(loss=result["eval_loss"])
 
 
-    def test(self, input_filepath, solve, dataclass_args: QATestArgs, encoding="utf-8"):
+    def test(self, input_filepath, solve, dataclass_args: QATestArgs):
         """
         See docstring in HappyQuestionAnswering.test()
 
@@ -121,7 +118,7 @@ class QATrainer(HappyTrainer):
                              "not available for question answering models. "
                              "It will be added soon. ")
 
-        contexts, questions = self._get_data(input_filepath, test_data=True, encoding=encoding)
+        contexts, questions = self._get_data(input_filepath, test_data=True)
 
         return [
             solve(context, question)[0]
@@ -130,7 +127,7 @@ class QATrainer(HappyTrainer):
         ]
 
     @staticmethod
-    def _get_data(filepath, encoding, test_data=False):
+    def _get_data(filepath, test_data=False):
         """
         Used to collect
         :param filepath: a string that contains the location of the data
@@ -140,7 +137,7 @@ class QATrainer(HappyTrainer):
         contexts = []
         questions = []
         answers = []
-        with open(filepath, newline='', encoding=encoding) as csv_file:
+        with open(filepath, newline='', encoding="utf-8") as csv_file:
             reader = csv.DictReader(csv_file)
             for row in reader:
                 contexts.append(row['context'])

--- a/happytransformer/qa/trainer.py
+++ b/happytransformer/qa/trainer.py
@@ -31,6 +31,7 @@ class QATrainArgs:
     load_preprocessed_data: bool = ARGS_QA_TRAIN["load_preprocessed_data"]
     load_preprocessed_data_path: str = ARGS_QA_TRAIN["load_preprocessed_data_path"]
     batch_size: int = ARGS_QA_TRAIN["batch_size"]
+    encoding: str = ARGS_QA_TRAIN["encoding"]
 
 
 @dataclass
@@ -40,6 +41,7 @@ class QAEvalArgs:
     save_preprocessed_data_path: str = ARGS_QA_EVAl["save_preprocessed_data_path"]
     load_preprocessed_data: bool = ARGS_QA_EVAl["load_preprocessed_data"]
     load_preprocessed_data_path: str = ARGS_QA_EVAl["load_preprocessed_data_path"]
+    encoding: str = ARGS_QA_EVAl["encoding"]
 
 
 @dataclass
@@ -48,6 +50,7 @@ class QATestArgs:
     save_preprocessed_data_path: str = ARGS_QA_TEST["save_preprocessed_data_path"]
     load_preprocessed_data: bool = ARGS_QA_TEST["load_preprocessed_data"]
     load_preprocessed_data_path: str = ARGS_QA_TEST["load_preprocessed_data_path"]
+    encoding: str = ARGS_QA_TEST["encoding"]
 
 
 class QATrainer(HappyTrainer):

--- a/happytransformer/qa/trainer.py
+++ b/happytransformer/qa/trainer.py
@@ -55,7 +55,7 @@ class QATrainer(HappyTrainer):
     Trainer class for HappyTextClassification
     """
 
-    def train(self, input_filepath, dataclass_args: QATrainArgs):
+    def train(self, input_filepath, dataclass_args: QATrainArgs, encoding="utf-8"):
         """
         See docstring in HappyQuestionAnswering.train()
         """
@@ -69,7 +69,7 @@ class QATrainer(HappyTrainer):
                              "It will be added soon. ")
 
         self.logger.info("Preprocessing dataset...")
-        contexts, questions, answers = self._get_data(input_filepath)
+        contexts, questions, answers = self._get_data(input_filepath, encoding=encoding)
         self.__add_end_idx(contexts, answers)
         encodings = self.tokenizer(contexts, questions, truncation=True, padding=True)
         self.__add_token_positions(encodings, answers)
@@ -77,7 +77,7 @@ class QATrainer(HappyTrainer):
         data_collator = DataCollatorWithPadding(self.tokenizer)
         self._run_train(dataset, dataclass_args, data_collator)
 
-    def eval(self, input_filepath, dataclass_args: QAEvalArgs):
+    def eval(self, input_filepath, dataclass_args: QAEvalArgs, encoding="utf-8"):
         """
         See docstring in HappyQuestionAnswering.eval()
 
@@ -91,7 +91,7 @@ class QATrainer(HappyTrainer):
                              "not available for question answering models. "
                              "It will be added soon. ")
 
-        contexts, questions, answers = self._get_data(input_filepath)
+        contexts, questions, answers = self._get_data(input_filepath, encoding=encoding)
 
         self.__add_end_idx(contexts, answers)
         encodings = self.tokenizer(contexts, questions, truncation=True, padding=True)
@@ -103,7 +103,7 @@ class QATrainer(HappyTrainer):
         return EvalResult(loss=result["eval_loss"])
 
 
-    def test(self, input_filepath, solve, dataclass_args: QATestArgs):
+    def test(self, input_filepath, solve, dataclass_args: QATestArgs, encoding="utf-8"):
         """
         See docstring in HappyQuestionAnswering.test()
 
@@ -118,7 +118,7 @@ class QATrainer(HappyTrainer):
                              "not available for question answering models. "
                              "It will be added soon. ")
 
-        contexts, questions = self._get_data(input_filepath, test_data=True)
+        contexts, questions = self._get_data(input_filepath, test_data=True, encoding=encoding)
 
         return [
             solve(context, question)[0]
@@ -127,7 +127,7 @@ class QATrainer(HappyTrainer):
         ]
 
     @staticmethod
-    def _get_data(filepath, test_data=False):
+    def _get_data(filepath, encoding, test_data=False):
         """
         Used to collect
         :param filepath: a string that contains the location of the data
@@ -137,7 +137,7 @@ class QATrainer(HappyTrainer):
         contexts = []
         questions = []
         answers = []
-        with open(filepath, newline='') as csv_file:
+        with open(filepath, newline='', encoding=encoding) as csv_file:
             reader = csv.DictReader(csv_file)
             for row in reader:
                 contexts.append(row['context'])

--- a/happytransformer/sp/default_args.py
+++ b/happytransformer/sp/default_args.py
@@ -6,7 +6,6 @@ ARGS_SP_TRAIN = {
     'adam_epsilon': 1e-8,
     'max_grad_norm':  1.0,
     'num_train_epochs': 3.0,
-    'encoding': "utf-8"
 
 }
 

--- a/happytransformer/sp/default_args.py
+++ b/happytransformer/sp/default_args.py
@@ -6,6 +6,7 @@ ARGS_SP_TRAIN = {
     'adam_epsilon': 1e-8,
     'max_grad_norm':  1.0,
     'num_train_epochs': 3.0,
+    'encoding': "utf-8"
 
 }
 

--- a/happytransformer/sp/default_args.py
+++ b/happytransformer/sp/default_args.py
@@ -6,7 +6,6 @@ ARGS_SP_TRAIN = {
     'adam_epsilon': 1e-8,
     'max_grad_norm':  1.0,
     'num_train_epochs': 3.0,
-
 }
 
 

--- a/happytransformer/tc/default_args.py
+++ b/happytransformer/tc/default_args.py
@@ -11,6 +11,7 @@ ARGS_TC_TRAIN = {
     'save_preprocessed_data_path': "",
     'load_preprocessed_data': False,
     'load_preprocessed_data_path': "",
+    'encoding': "utf-8"
 }
 
 ARGS_TC_EVAL = {
@@ -19,6 +20,8 @@ ARGS_TC_EVAL = {
     'save_preprocessed_data_path': "",
     'load_preprocessed_data': False,
     'load_preprocessed_data_path': "",
+    'encoding': "utf-8"
+
 }
 
 ARGS_TC_TEST = {
@@ -26,6 +29,7 @@ ARGS_TC_TEST = {
     'save_preprocessed_data_path': "",
     'load_preprocessed_data': False,
     'load_preprocessed_data_path': "",
+    'encoding': "utf-8"
 
 }
 

--- a/happytransformer/tc/default_args.py
+++ b/happytransformer/tc/default_args.py
@@ -11,7 +11,6 @@ ARGS_TC_TRAIN = {
     'save_preprocessed_data_path': "",
     'load_preprocessed_data': False,
     'load_preprocessed_data_path': "",
-    'encoding': "utf-8"
 }
 
 ARGS_TC_EVAL = {
@@ -20,7 +19,6 @@ ARGS_TC_EVAL = {
     'save_preprocessed_data_path': "",
     'load_preprocessed_data': False,
     'load_preprocessed_data_path': "",
-    'encoding': "utf-8"
 
 }
 
@@ -29,7 +27,6 @@ ARGS_TC_TEST = {
     'save_preprocessed_data_path': "",
     'load_preprocessed_data': False,
     'load_preprocessed_data_path': "",
-    'encoding': "utf-8"
 
 }
 

--- a/happytransformer/tc/default_args.py
+++ b/happytransformer/tc/default_args.py
@@ -19,7 +19,6 @@ ARGS_TC_EVAL = {
     'save_preprocessed_data_path': "",
     'load_preprocessed_data': False,
     'load_preprocessed_data_path': "",
-
 }
 
 ARGS_TC_TEST = {
@@ -27,6 +26,5 @@ ARGS_TC_TEST = {
     'save_preprocessed_data_path': "",
     'load_preprocessed_data': False,
     'load_preprocessed_data_path': "",
-
 }
 

--- a/happytransformer/tc/trainer.py
+++ b/happytransformer/tc/trainer.py
@@ -54,7 +54,9 @@ class TCTrainer(HappyTrainer):
     """
 
     def train(self, input_filepath, dataclass_args: TCTrainArgs, encoding="utf-8"):
-
+        """
+        :param encoding: name of the encoding used to decode the file
+        """
         if not dataclass_args.load_preprocessed_data:
             self.logger.info("Preprocessing dataset...")
             contexts, labels = self._get_data(input_filepath, encoding=encoding)
@@ -73,10 +75,10 @@ class TCTrainer(HappyTrainer):
         data_collator = DataCollatorWithPadding(self.tokenizer)
         self._run_train(train_dataset, dataclass_args, data_collator)
 
-    def eval(self, input_filepath, dataclass_args: TCEvalArgs):
+    def eval(self, input_filepath, dataclass_args: TCEvalArgs, encoding="utf-8"):
         if not dataclass_args.load_preprocessed_data:
             self.logger.info("Preprocessing dataset...")
-            contexts, labels = self._get_data(input_filepath)
+            contexts, labels = self._get_data(input_filepath, encoding=encoding)
             eval_encodings = self.tokenizer(contexts, truncation=True, padding=True)
         else:
             self.logger.info("Loading dataset from %s...", dataclass_args.load_preprocessed_data_path)
@@ -95,12 +97,12 @@ class TCTrainer(HappyTrainer):
         result = self._run_eval(eval_dataset, data_collator, dataclass_args)
         return EvalResult(loss=result["eval_loss"])
 
-    def test(self, input_filepath, solve, dataclass_args: TCTestArgs):
+    def test(self, input_filepath, solve, dataclass_args: TCTestArgs, encoding="utf-8"):
         """
         See docstring in HappyQuestionAnswering.test()
         solve: HappyQuestionAnswering.answers_to_question()
         """
-        contexts = self._get_data(input_filepath, test_data=True)
+        contexts = self._get_data(input_filepath, test_data=True, encoding=encoding)
 
         return [
             solve(context)

--- a/happytransformer/tc/trainer.py
+++ b/happytransformer/tc/trainer.py
@@ -30,6 +30,7 @@ class TCTrainArgs:
     save_preprocessed_data_path: str = ARGS_TC_TRAIN["save_preprocessed_data_path"]
     load_preprocessed_data: bool = ARGS_TC_TRAIN["load_preprocessed_data"]
     load_preprocessed_data_path: str = ARGS_TC_TRAIN["load_preprocessed_data_path"]
+    encoding: str = ARGS_TC_TRAIN["encoding"]
 
 
 @dataclass
@@ -39,6 +40,7 @@ class TCEvalArgs:
     load_preprocessed_data: bool = ARGS_TC_EVAL["load_preprocessed_data"]
     load_preprocessed_data_path: str = ARGS_TC_EVAL["load_preprocessed_data_path"]
     batch_size: int = ARGS_TC_EVAL["batch_size"]
+    encoding: str = ARGS_TC_EVAL["encoding"]
 
 
 @dataclass
@@ -47,19 +49,20 @@ class TCTestArgs:
     save_preprocessed_data_path: str = ARGS_TC_TEST["save_preprocessed_data_path"]
     load_preprocessed_data: bool = ARGS_TC_TEST["load_preprocessed_data"]
     load_preprocessed_data_path: str = ARGS_TC_TEST["load_preprocessed_data_path"]
+    encoding: str = ARGS_TC_TEST["encoding"]
 
 class TCTrainer(HappyTrainer):
     """
     A class for training text classification functionality
     """
 
-    def train(self, input_filepath, dataclass_args: TCTrainArgs, encoding="utf-8"):
+    def train(self, input_filepath, dataclass_args: TCTrainArgs):
         """
         :param encoding: name of the encoding used to decode the file
         """
         if not dataclass_args.load_preprocessed_data:
             self.logger.info("Preprocessing dataset...")
-            contexts, labels = self._get_data(input_filepath, encoding=encoding)
+            contexts, labels = self._get_data(input_filepath, encoding=TCTrainArgs.encoding)
             train_encodings = self.tokenizer(contexts, truncation=True, padding=True)
         else:
             self.logger.info("Loading dataset from %s...", dataclass_args.load_preprocessed_data_path)
@@ -75,10 +78,10 @@ class TCTrainer(HappyTrainer):
         data_collator = DataCollatorWithPadding(self.tokenizer)
         self._run_train(train_dataset, dataclass_args, data_collator)
 
-    def eval(self, input_filepath, dataclass_args: TCEvalArgs, encoding="utf-8"):
+    def eval(self, input_filepath, dataclass_args: TCEvalArgs):
         if not dataclass_args.load_preprocessed_data:
             self.logger.info("Preprocessing dataset...")
-            contexts, labels = self._get_data(input_filepath, encoding=encoding)
+            contexts, labels = self._get_data(input_filepath, encoding=TCEvalArgs.encoding)
             eval_encodings = self.tokenizer(contexts, truncation=True, padding=True)
         else:
             self.logger.info("Loading dataset from %s...", dataclass_args.load_preprocessed_data_path)
@@ -97,12 +100,12 @@ class TCTrainer(HappyTrainer):
         result = self._run_eval(eval_dataset, data_collator, dataclass_args)
         return EvalResult(loss=result["eval_loss"])
 
-    def test(self, input_filepath, solve, dataclass_args: TCTestArgs, encoding="utf-8"):
+    def test(self, input_filepath, solve, dataclass_args: TCTestArgs):
         """
         See docstring in HappyQuestionAnswering.test()
         solve: HappyQuestionAnswering.answers_to_question()
         """
-        contexts = self._get_data(input_filepath, test_data=True, encoding=encoding)
+        contexts = self._get_data(input_filepath, test_data=True, encoding=TCTestArgs.encoding)
 
         return [
             solve(context)
@@ -110,7 +113,7 @@ class TCTrainer(HappyTrainer):
         ]
 
     @staticmethod
-    def _get_data(filepath, encoding, test_data=False):
+    def _get_data(filepath, encoding="utf-8", test_data=False):
         """
         Used for parsing data for training and evaluating (both contain labels)
         :param filepath: a string that contains the location of the data

--- a/happytransformer/tc/trainer.py
+++ b/happytransformer/tc/trainer.py
@@ -30,7 +30,6 @@ class TCTrainArgs:
     save_preprocessed_data_path: str = ARGS_TC_TRAIN["save_preprocessed_data_path"]
     load_preprocessed_data: bool = ARGS_TC_TRAIN["load_preprocessed_data"]
     load_preprocessed_data_path: str = ARGS_TC_TRAIN["load_preprocessed_data_path"]
-    encoding: str = ARGS_TC_TRAIN["encoding"]
 
 
 @dataclass
@@ -40,7 +39,6 @@ class TCEvalArgs:
     load_preprocessed_data: bool = ARGS_TC_EVAL["load_preprocessed_data"]
     load_preprocessed_data_path: str = ARGS_TC_EVAL["load_preprocessed_data_path"]
     batch_size: int = ARGS_TC_EVAL["batch_size"]
-    encoding: str = ARGS_TC_EVAL["encoding"]
 
 
 @dataclass
@@ -49,7 +47,6 @@ class TCTestArgs:
     save_preprocessed_data_path: str = ARGS_TC_TEST["save_preprocessed_data_path"]
     load_preprocessed_data: bool = ARGS_TC_TEST["load_preprocessed_data"]
     load_preprocessed_data_path: str = ARGS_TC_TEST["load_preprocessed_data_path"]
-    encoding: str = ARGS_TC_TEST["encoding"]
 
 class TCTrainer(HappyTrainer):
     """
@@ -58,11 +55,10 @@ class TCTrainer(HappyTrainer):
 
     def train(self, input_filepath, dataclass_args: TCTrainArgs):
         """
-        :param encoding: name of the encoding used to decode the file
         """
         if not dataclass_args.load_preprocessed_data:
             self.logger.info("Preprocessing dataset...")
-            contexts, labels = self._get_data(input_filepath, encoding=TCTrainArgs.encoding)
+            contexts, labels = self._get_data(input_filepath)
             train_encodings = self.tokenizer(contexts, truncation=True, padding=True)
         else:
             self.logger.info("Loading dataset from %s...", dataclass_args.load_preprocessed_data_path)
@@ -81,7 +77,7 @@ class TCTrainer(HappyTrainer):
     def eval(self, input_filepath, dataclass_args: TCEvalArgs):
         if not dataclass_args.load_preprocessed_data:
             self.logger.info("Preprocessing dataset...")
-            contexts, labels = self._get_data(input_filepath, encoding=TCEvalArgs.encoding)
+            contexts, labels = self._get_data(input_filepath)
             eval_encodings = self.tokenizer(contexts, truncation=True, padding=True)
         else:
             self.logger.info("Loading dataset from %s...", dataclass_args.load_preprocessed_data_path)
@@ -105,7 +101,7 @@ class TCTrainer(HappyTrainer):
         See docstring in HappyQuestionAnswering.test()
         solve: HappyQuestionAnswering.answers_to_question()
         """
-        contexts = self._get_data(input_filepath, test_data=True, encoding=TCTestArgs.encoding)
+        contexts = self._get_data(input_filepath, test_data=True)
 
         return [
             solve(context)
@@ -113,7 +109,7 @@ class TCTrainer(HappyTrainer):
         ]
 
     @staticmethod
-    def _get_data(filepath, encoding="utf-8", test_data=False):
+    def _get_data(filepath, test_data=False):
         """
         Used for parsing data for training and evaluating (both contain labels)
         :param filepath: a string that contains the location of the data
@@ -121,7 +117,7 @@ class TCTrainer(HappyTrainer):
         """
         contexts = []
         labels = []
-        with open(filepath, newline='', encoding=encoding) as csv_file:
+        with open(filepath, newline='', encoding="utf-8") as csv_file:
             reader = csv.DictReader(csv_file)
             for row in reader:
                 contexts.append(row['text'])

--- a/happytransformer/tc/trainer.py
+++ b/happytransformer/tc/trainer.py
@@ -54,8 +54,7 @@ class TCTrainer(HappyTrainer):
     """
 
     def train(self, input_filepath, dataclass_args: TCTrainArgs):
-        """
-        """
+
         if not dataclass_args.load_preprocessed_data:
             self.logger.info("Preprocessing dataset...")
             contexts, labels = self._get_data(input_filepath)

--- a/happytransformer/tc/trainer.py
+++ b/happytransformer/tc/trainer.py
@@ -53,11 +53,11 @@ class TCTrainer(HappyTrainer):
     A class for training text classification functionality
     """
 
-    def train(self, input_filepath, dataclass_args: TCTrainArgs):
+    def train(self, input_filepath, dataclass_args: TCTrainArgs, encoding="utf-8"):
 
         if not dataclass_args.load_preprocessed_data:
             self.logger.info("Preprocessing dataset...")
-            contexts, labels = self._get_data(input_filepath)
+            contexts, labels = self._get_data(input_filepath, encoding=encoding)
             train_encodings = self.tokenizer(contexts, truncation=True, padding=True)
         else:
             self.logger.info("Loading dataset from %s...", dataclass_args.load_preprocessed_data_path)
@@ -108,7 +108,7 @@ class TCTrainer(HappyTrainer):
         ]
 
     @staticmethod
-    def _get_data(filepath, test_data=False):
+    def _get_data(filepath, encoding, test_data=False):
         """
         Used for parsing data for training and evaluating (both contain labels)
         :param filepath: a string that contains the location of the data
@@ -116,7 +116,7 @@ class TCTrainer(HappyTrainer):
         """
         contexts = []
         labels = []
-        with open(filepath, newline='') as csv_file:
+        with open(filepath, newline='', encoding=encoding) as csv_file:
             reader = csv.DictReader(csv_file)
             for row in reader:
                 contexts.append(row['text'])

--- a/tests/test_gen.py
+++ b/tests/test_gen.py
@@ -10,14 +10,14 @@ from happytransformer import (
 from tests.shared_tests import run_save_load
 
 def test_default_simple():
-    happy_gen = HappyGeneration()
+    happy_gen = HappyGeneration("GPT-2", "sshleifer/tiny-gpt2")
     args = GENSettings(min_length=5, max_length=5)
     output = happy_gen.generate_text("Artificial intelligence is ", args=args)
     assert type(output.text) == str
 
 
 def test_default_min_max_length():
-    happy_gen = HappyGeneration()
+    happy_gen = HappyGeneration("GPT-2", "sshleifer/tiny-gpt2")
     args = GENSettings(min_length=5, max_length=5)
     output = happy_gen.generate_text("Artificial intelligence is ", args=args)
     tokens = happy_gen.tokenizer.encode(output.text, return_tensors="pt")
@@ -25,7 +25,7 @@ def test_default_min_max_length():
     assert length == 5
 
 def test_bad_words():
-    happy_gen = HappyGeneration()
+    happy_gen = HappyGeneration("GPT-2", "sshleifer/tiny-gpt2")
     # Test single words
     args_test_word_single = GENSettings(bad_words=["new", "tool"])
     # result without bad_words:  "a new field of research that has been gaining momentum"
@@ -42,7 +42,7 @@ def test_bad_words():
 
 
 def test_top_p():
-    happy_gen = HappyGeneration()
+    happy_gen = HappyGeneration("GPT-2", "sshleifer/tiny-gpt2")
     # Test small values
     args_small = GENSettings(top_p=0.01,  max_length=5)
     output_small = happy_gen.generate_text("Artificial intelligence is ", args=args_small)
@@ -60,7 +60,7 @@ def test_top_p():
 
 
 def test_all_methods():
-    happy_gen = HappyGeneration()
+    happy_gen = HappyGeneration("GPT-2", "sshleifer/tiny-gpt2")
 
     greedy_settings = GENSettings(min_length=5, max_length=5, no_repeat_ngram_size=2)
     output_greedy = happy_gen.generate_text(
@@ -105,16 +105,16 @@ def test_all_methods():
     print("top-p-sampling: ", output_top_p_sampling.text, end="\n\n")
 
 def test_gen_train_basic():
-    happy_gen = HappyGeneration()
+    happy_gen = HappyGeneration("GPT-2", "sshleifer/tiny-gpt2")
     happy_gen.train("../data/gen/train-eval.txt")
 
 def test_gen_eval_basic():
-    happy_gen = HappyGeneration()
+    happy_gen = HappyGeneration("GPT-2", "sshleifer/tiny-gpt2")
     result = happy_gen.eval("../data/gen/train-eval.txt")
     assert type(result.loss) == float
 
 def test_gen_train_effectiveness_multi():
-    happy_gen = HappyGeneration()
+    happy_gen = HappyGeneration("GPT-2", "sshleifer/tiny-gpt2")
     before_result = happy_gen.eval("../data/gen/train-eval.txt")
     happy_gen.train("../data/gen/train-eval.txt")
     after_result = happy_gen.eval("../data/gen/train-eval.txt")
@@ -122,19 +122,19 @@ def test_gen_train_effectiveness_multi():
     assert after_result.loss < before_result.loss
 
 def test_gen_save_load_train():
-    happy_gen = HappyGeneration()
+    happy_gen = HappyGeneration("GPT-2", "sshleifer/tiny-gpt2")
     output_path = "data/gen-train.txt"
     data_path = "../data/gen/train-eval.txt"
     run_save_load(happy_gen, output_path, ARGS_GEN_TRAIN, data_path, "train")
 
 def test_gen_save_load_eval():
-    happy_gen = HappyGeneration()
+    happy_gen = HappyGeneration("GPT-2", "sshleifer/tiny-gpt2")
     output_path = "data/wp-eval.txt"
     data_path = "../data/gen/train-eval.txt"
     run_save_load(happy_gen, output_path, ARGS_GEN_EVAl, data_path, "eval")
 
 def test_gen_save():
-    happy = HappyGeneration()
+    happy = HappyGeneration("GPT-2", "sshleifer/tiny-gpt2")
     happy.save("model/")
     result_before = happy.generate_text("Natural language processing is")
 
@@ -145,7 +145,7 @@ def test_gen_save():
 
 def test_wp_train_eval_with_dic():
 
-    happy_gen = HappyGeneration()
+    happy_gen = HappyGeneration("GPT-2", "sshleifer/tiny-gpt2")
     train_args = {'learning_rate': 0.01,  "num_train_epochs": 1}
 
 
@@ -158,7 +158,7 @@ def test_wp_train_eval_with_dic():
 
 def test_gen_train_eval_with_dataclass():
 
-    happy_gen = HappyGeneration()
+    happy_gen = HappyGeneration("GPT-2", "sshleifer/tiny-gpt2")
     train_args = GENTrainArgs(learning_rate=0.01, num_train_epochs=1)
 
     happy_gen.train("../data/gen/train-eval.txt" , args=train_args)
@@ -170,7 +170,7 @@ def test_gen_train_eval_with_dataclass():
     assert type(after_result.loss) == float
 
 def test_generate_after_train_eval():
-    happy_gen = HappyGeneration()
+    happy_gen = HappyGeneration("GPT-2", "sshleifer/tiny-gpt2")
     happy_gen.train("../data/gen/train-eval.txt")
     eval_result = happy_gen.eval("../data/gen/train-eval.txt")
     output = happy_gen.generate_text("Artificial intelligence is ")

--- a/tests/test_ns.py
+++ b/tests/test_ns.py
@@ -2,7 +2,7 @@ from happytransformer import HappyNextSentence
 
 
 def test_sp_true():
-    happy_ns = HappyNextSentence()
+    happy_ns = HappyNextSentence("BERT", "prajjwal1/bert-tiny")
     result = happy_ns.predict_next_sentence(
         "Hi nice to meet you. How old are you?",
         "I am 21 years old."
@@ -11,7 +11,7 @@ def test_sp_true():
 
 
 def test_sp_false():
-    happy_ns = HappyNextSentence()
+    happy_ns = HappyNextSentence("BERT", "prajjwal1/bert-tiny")
     result = happy_ns.predict_next_sentence(
         "How old are you?",
         "The Eiffel Tower is in Paris."
@@ -19,7 +19,7 @@ def test_sp_false():
     assert result < 0.5
 
 def test_sp_save():
-    happy = HappyNextSentence()
+    happy = HappyNextSentence("BERT", "prajjwal1/bert-tiny")
     happy.save("model/")
     result_before = happy.predict_next_sentence(
         "How old are you?",

--- a/tests/test_qa.py
+++ b/tests/test_qa.py
@@ -13,7 +13,7 @@ from pytest import approx
 
 def test_qa_basic():
 
-    happy_qa = HappyQuestionAnswering()
+    happy_qa = HappyQuestionAnswering("DISTILBERT", "distilbert-base-cased-distilled-squad")
     result = happy_qa.answer_question("Today's date is January 8th 2021", "What is the date?", top_k=10)
     assert result[0].answer == 'January 8th 2021'
     assert result[0].score == approx(0.9696964621543884, 1)
@@ -40,7 +40,8 @@ def test_qa_eval():
 
 
 def test_qa_test():
-    happy_qa = HappyQuestionAnswering()
+    happy_qa = HappyQuestionAnswering(model_type='DISTILBERT',
+        model_name='distilbert-base-cased-distilled-squad')
     results = happy_qa.test("../data/qa/test.csv")
     assert results[0].answer == 'October 31st'
     assert results[1].answer == 'November 23rd'
@@ -52,7 +53,8 @@ def test_qa_train_effectiveness():
     lowering the loss as determined by HappyQuestionAnswering.eval()
     """
     # use a non-fine-tuned model so we DEFINITELY get an improvement
-    happy_qa = HappyQuestionAnswering()
+    happy_qa = HappyQuestionAnswering(model_type='DISTILBERT',
+        model_name='distilbert-base-cased-distilled-squad')
     before_loss = happy_qa.eval("../data/qa/train-eval.csv").loss
     happy_qa.train("../data/qa/train-eval.csv")
     after_loss = happy_qa.eval("../data/qa/train-eval.csv").loss
@@ -61,7 +63,8 @@ def test_qa_train_effectiveness():
 
 
 def test_qa_save():
-    happy = HappyQuestionAnswering()
+    happy = HappyQuestionAnswering(model_type='DISTILBERT',
+        model_name='distilbert-base-cased-distilled-squad')
     happy.save("model/")
     result_before = happy.answer_question("Natural language processing is a subfield of artificial surrounding creating models that understand language","What is natural language processing?")
 
@@ -73,7 +76,8 @@ def test_qa_save():
 
 def test_qa_with_dic():
 
-    happy_qa = HappyQuestionAnswering()
+    happy_qa = HappyQuestionAnswering(model_type='DISTILBERT',
+        model_name='distilbert-base-cased-distilled-squad')
     train_args = {'learning_rate': 0.01,  "num_train_epochs": 1}
 
 
@@ -91,7 +95,8 @@ def test_qa_with_dic():
 
 def test_tc_with_dataclass():
 
-    happy_qa = HappyQuestionAnswering()
+    happy_qa = HappyQuestionAnswering(model_type='DISTILBERT',
+        model_name='distilbert-base-cased-distilled-squad')
     train_args = QATrainArgs(learning_rate=0.01, num_train_epochs=1)
 
     happy_qa.train("../data/qa/train-eval.csv", args=train_args)

--- a/tests/test_tc.py
+++ b/tests/test_tc.py
@@ -78,10 +78,10 @@ def test_tc_train_effectiveness_multi():
     after_loss = happy_tc.eval("../data/tc/train-eval-multi.csv").loss
     assert after_loss < before_loss
 
-
+#TODO investigate why with some models the labels change after is saved and loaded
 def test_tc_save():
-    happy = HappyTextClassification(model_type="BERT",
-        model_name="prajjwal1/bert-tiny")
+    happy = HappyTextClassification(model_type="DISTILBERT",
+        model_name="distilbert-base-uncased", num_labels=2)
     happy.save("model/")
     result_before = happy.classify_text("What a great movie")
 

--- a/tests/test_tc.py
+++ b/tests/test_tc.py
@@ -15,7 +15,6 @@ from tests.shared_tests import run_save_load
 from pytest import approx
 
 
-
 def test_classify_text():
     happy_tc = HappyTextClassification(model_type="DISTILBERT", model_name="distilbert-base-uncased-finetuned-sst-2-english")
     result = happy_tc.classify_text("What a great movie")
@@ -25,8 +24,8 @@ def test_classify_text():
 
 def test_tc_train():
     happy_tc = HappyTextClassification(
-        model_type="DISTILBERT",
-        model_name="distilbert-base-uncased-finetuned-sst-2-english"
+        model_type="BERT",
+        model_name="prajjwal1/bert-tiny"
     )
     results = happy_tc.train("../data/tc/train-eval.csv")
 
@@ -58,8 +57,8 @@ def test_tc_test():
 def test_tc_train_effectiveness():
     """assert that training decreases the loss"""
     happy_tc = HappyTextClassification(
-        model_type="DISTILBERT",
-        model_name="distilbert-base-uncased"
+        model_type="BERT",
+        model_name="prajjwal1/bert-tiny"
     )
     before_loss = happy_tc.eval("../data/tc/train-eval.csv").loss
     happy_tc.train("../data/tc/train-eval.csv")
@@ -70,8 +69,8 @@ def test_tc_train_effectiveness():
 def test_tc_train_effectiveness_multi():
     
     happy_tc = HappyTextClassification(
-        model_type="DISTILBERT",
-        model_name="distilbert-base-uncased", 
+        model_type="BERT",
+        model_name="prajjwal1/bert-tiny",
         num_labels=3
     )
     before_loss = happy_tc.eval("../data/tc/train-eval-multi.csv").loss
@@ -81,7 +80,8 @@ def test_tc_train_effectiveness_multi():
 
 
 def test_tc_save():
-    happy = HappyTextClassification()
+    happy = HappyTextClassification(model_type="BERT",
+        model_name="prajjwal1/bert-tiny")
     happy.save("model/")
     result_before = happy.classify_text("What a great movie")
 
@@ -93,7 +93,8 @@ def test_tc_save():
 
 def test_tc_with_dic():
 
-    happy_tc = HappyTextClassification()
+    happy_tc = HappyTextClassification(model_type="BERT",
+        model_name="prajjwal1/bert-tiny")
     train_args = {'learning_rate': 0.01,  "num_train_epochs": 1}
 
 
@@ -110,7 +111,8 @@ def test_tc_with_dic():
 
 def test_tc_with_dataclass():
 
-    happy_tc = HappyTextClassification()
+    happy_tc = HappyTextClassification(model_type="BERT",
+        model_name="prajjwal1/bert-tiny")
     train_args = TCTrainArgs(learning_rate=0.01, num_train_epochs=1)
 
     happy_tc.train("../data/tc/train-eval.csv", args=train_args)
@@ -125,14 +127,15 @@ def test_tc_with_dataclass():
     result_test = happy_tc.test("../data/tc/test.csv", args=test_args)
 
 def test_tc_save_load_train():
-    happy_wp = HappyTextClassification()
+    happy_wp = HappyTextClassification(model_type="BERT",
+        model_name="prajjwal1/bert-tiny")
     output_path = "data/tc-train.json"
     data_path = "../data/tc/train-eval.csv"
     run_save_load(happy_wp, output_path, ARGS_TC_TRAIN, data_path, "train")
 
 
 def test_tc_save_load_eval():
-    happy_wp = HappyTextClassification()
+    happy_wp = HappyTextClassification(model_type="DISTILBERT", model_name="distilbert-base-uncased-finetuned-sst-2-english")
     output_path = "data/tc-train.json"
     data_path = "../data/tc/train-eval.csv"
     run_save_load(happy_wp, output_path, ARGS_TC_EVAL, data_path, "eval")

--- a/tests/test_toc.py
+++ b/tests/test_toc.py
@@ -10,7 +10,7 @@ def test_classify_text():
     assert result == expected_result
 
 def test_toc_save():
-    happy = HappyTokenClassification()
+    happy = HappyTokenClassification(model_type="BERT", model_name="dslim/bert-base-NER")
     happy.save("model/")
     result_before = happy.classify_token("My name is Geoffrey and I live in Toronto")
 

--- a/tests/test_tt.py
+++ b/tests/test_tt.py
@@ -3,12 +3,12 @@ from happytransformer import HappyTextToText, TTSettings, TTTrainArgs, TTEvalArg
 
 
 def test_default_simple():
-    happy_tt = HappyTextToText()
+    happy_tt = HappyTextToText("T5", "t5-small")
     output = happy_tt.generate_text("translate English to French: Hello my name is Eric")
     assert type(output.text) == str
 
 def test_default_min_max_length():
-    happy_tt = HappyTextToText()
+    happy_tt = HappyTextToText("T5", "t5-small")
     args = TTSettings(min_length=5, max_length=5)
     output = happy_tt.generate_text("translate English to French: Hello my name is Eric", args=args)
     tokens = happy_tt.tokenizer.encode(output.text, return_tensors="pt")
@@ -16,7 +16,7 @@ def test_default_min_max_length():
     assert length == 5
 
 def test_all_methods():
-    happy_tt = HappyTextToText()
+    happy_tt = HappyTextToText("T5", "t5-small")
 
     greedy_settings = TTSettings(min_length=5, max_length=5, no_repeat_ngram_size=2)
     output_greedy = happy_tt.generate_text(
@@ -61,7 +61,7 @@ def test_all_methods():
     print("top-p-sampling: ", output_top_p_sampling.text, end="\n\n")
 
 def test_tt_save():
-    happy_tt = HappyTextToText()
+    happy_tt = HappyTextToText("T5", "t5-small")
     happy_tt.save("model/")
     result_before = happy_tt.generate_text("translate English to French: Hello my name is Eric")
 
@@ -72,15 +72,15 @@ def test_tt_save():
 
 
 def test_tt_train_simple():
-    happy_tt = HappyTextToText()
+    happy_tt = HappyTextToText("T5", "t5-small")
     happy_tt.train("../data/tt/train-eval-grammar.csv")
 
 def test_tt_eval_simple():
-    happy_tt = HappyTextToText()
+    happy_tt = HappyTextToText("T5", "t5-small")
     happy_tt.eval("../data/tt/train-eval-grammar.csv")
 
 def test_tt_eval_loss_decreases():
-    happy_tt = HappyTextToText()
+    happy_tt = HappyTextToText("T5", "t5-small")
 
     before_result = happy_tt.eval("../data/tt/train-eval-grammar.csv")
     happy_tt.train("../data/tt/train-eval-grammar.csv")
@@ -89,12 +89,12 @@ def test_tt_eval_loss_decreases():
     assert before_result.loss > after_result.loss
 
 def test_tt_train_custom_p():
-    happy_tt = HappyTextToText()
+    happy_tt = HappyTextToText("T5", "t5-small")
     args = TTTrainArgs(num_train_epochs=2, max_input_length=100, max_output_length=100, preprocessing_processes=4, batch_size=2)
     happy_tt.train("../data/tt/train-eval-grammar.csv", args=args)
 
 def test_tt_eval_custom_p():
-    happy_tt = HappyTextToText()
+    happy_tt = HappyTextToText("T5", "t5-small")
     args = TTEvalArgs(max_input_length=100, max_output_length=100, preprocessing_processes=4, batch_size=2)
     result = happy_tt.eval("../data/tt/train-eval-grammar.csv", args=args)
     assert type(result.loss) is float

--- a/tests/test_wp.py
+++ b/tests/test_wp.py
@@ -29,11 +29,11 @@ def test_wp_basic():
 
 def test_wp_high_k():
 
-    happy_wp = HappyWordPrediction("ALBERT", "albert-base-v2")
+    happy_wp = HappyWordPrediction("DISTILBERT", "distilbert-base-uncased")
     results = happy_wp.predict_mask(
         "Please pass the salt and [MASK]", top_k=3000
     )
-    assert results[0].token == "garlic"
+    assert results[0].token == "pepper"
 
 def test_wp_top_k():
     happy_wp = HappyWordPrediction('DISTILBERT', 'distilbert-base-uncased')
@@ -61,22 +61,22 @@ def test_wp_targets():
 
 
 def test_wp_train_default():
-    happy_wp = HappyWordPrediction('', 'distilroberta-base')
+    happy_wp = HappyWordPrediction('BERT', 'prajjwal1/bert-tiny')
     happy_wp.train("../data/wp/train-eval.txt")
 
 def test_wp_train_line_by_line():
-    happy_wp = HappyWordPrediction('', 'distilroberta-base')
+    happy_wp = HappyWordPrediction('BERT', 'prajjwal1/bert-tiny')
     happy_wp.train("../data/wp/train-eval.txt", args=WPTrainArgs(line_by_line=True))
 
 
 
 def test_wp_eval_basic():
-    happy_wp = HappyWordPrediction('', 'distilroberta-base')
+    happy_wp = HappyWordPrediction('BERT', 'prajjwal1/bert-tiny')
     result = happy_wp.eval("../data/wp/train-eval.txt")
     assert type(result.loss) == float
 
 def test_wp_train_effectiveness_multi():
-    happy_wp = HappyWordPrediction('', 'distilroberta-base')
+    happy_wp = HappyWordPrediction('BERT', 'prajjwal1/bert-tiny')
 
     before_result = happy_wp.eval("../data/wp/train-eval.txt")
 
@@ -92,13 +92,13 @@ def test_wp_eval_some_settings():
     """
     args = {'line_by_line': True,
             }
-    happy_wp = HappyWordPrediction('', 'distilroberta-base')
+    happy_wp = HappyWordPrediction('BERT', 'prajjwal1/bert-tiny')
     result = happy_wp.eval("../data/wp/train-eval.txt", args)
     assert type(result.loss) == float
 
 
 def test_wp_save_load_train():
-    happy_wp = HappyWordPrediction('', 'distilroberta-base')
+    happy_wp = HappyWordPrediction('BERT', 'prajjwal1/bert-tiny')
     output_path = "data/wp-train.json"
     data_path = "../data/wp/train-eval.txt"
     args = ARGS_WP_TRAIN
@@ -106,7 +106,7 @@ def test_wp_save_load_train():
     run_save_load(happy_wp, output_path, args, data_path, "train")
 
 def test_wp_save_load_eval():
-    happy_wp = HappyWordPrediction('', 'distilroberta-base')
+    happy_wp = HappyWordPrediction('BERT', 'prajjwal1/bert-tiny')
     output_path = "data/wp-eval.json"
     data_path = "../data/wp/train-eval.txt"
     args = ARGS_WP_EVAl
@@ -126,7 +126,7 @@ def test_wp_save():
 
 def test_wp_train_eval_with_dic():
 
-    happy_wp = HappyWordPrediction('', 'distilroberta-base')
+    happy_wp = HappyWordPrediction('BERT', 'prajjwal1/bert-tiny')
     train_args = {'learning_rate': 0.01, 'line_by_line': True, "num_train_epochs": 1}
 
 
@@ -138,7 +138,7 @@ def test_wp_train_eval_with_dic():
 
 def test_wp_train_eval_with_dataclass():
 
-    happy_wp = HappyWordPrediction('', 'distilroberta-base')
+    happy_wp = HappyWordPrediction('BERT', 'prajjwal1/bert-tiny')
     train_args = WPTrainArgs(learning_rate=0.01, line_by_line=True, num_train_epochs=1)
 
     happy_wp.train("../data/wp/train-eval.txt" , args=train_args)


### PR DESCRIPTION
Follow up from #265. 

These changes set the encoding format to "utf-8" for all training methods. This encoding format is recommended by Hugging Face and is the only encoding format available for Hugging Face's load_dataset() function. At first, I thought we should add the ability for users to adjust the encoding format, but since it's unchangeable when using load_dataset(), this would result in major changes as we rely on load_dataset() for WPTrainer, TTTrainer and GENTrainer. 

These changes may alter performance for those who are running on systems that use another encoding format by default. So, the next release will be upgraded from 2.3.3 to 2.4.0.  

I also updated various test cases to standardize the models which are used and to decrease the size of the used models. This will decrease the runtime of our test cases. 
 