### PR TITLE
Updated save strategy

### DIFF
--- a/happytransformer/happy_trainer.py
+++ b/happytransformer/happy_trainer.py
@@ -75,9 +75,9 @@ class HappyTrainer:
             max_grad_norm=dataclass_args.max_grad_norm,
             num_train_epochs=dataclass_args.num_train_epochs,
             report_to=["none"],
+            save_strategy="no",
             per_device_train_batch_size=dataclass_args.batch_size,
             fp16=dataclass_args.fp16,
-            save_strategy="no"  # no checkpoints are saved
 
         )
 

--- a/happytransformer/happy_trainer.py
+++ b/happytransformer/happy_trainer.py
@@ -76,7 +76,8 @@ class HappyTrainer:
             num_train_epochs=dataclass_args.num_train_epochs,
             report_to=["none"],
             per_device_train_batch_size=dataclass_args.batch_size,
-            fp16=dataclass_args.fp16
+            fp16=dataclass_args.fp16,
+            save_strategy="no"  # no checkpoints are saved
 
         )
 

--- a/happytransformer/tt/trainer.py
+++ b/happytransformer/tt/trainer.py
@@ -123,7 +123,7 @@ class TTTrainer(HappyTrainer):
                 max_grad_norm=dataclass_args.max_grad_norm,
                 num_train_epochs=dataclass_args.num_train_epochs,
                 report_to=["none"],
-                save_strategy="no", # no checkpoints are saved
+                save_strategy="no",
                 per_device_train_batch_size=dataclass_args.batch_size,
                 fp16=dataclass_args.fp16
 


### PR DESCRIPTION
Sets TrainingArguments's "save_strategy"  parameter to "no" by default, which means that the model will not be saved at all during training.  Right now, the output path is a temporary directory, so even if the model was to be saved during training it would be deleted immediately afterwards. In the future we can consider adding the ability to use custom save strategies. 

HappyTextToText uses custom training code, and already sets save_strategy to no by default . 
