### PR TITLE
Add preliminary support for TensorFlow in text generation.

### DIFF
--- a/happytransformer/__init__.py
+++ b/happytransformer/__init__.py
@@ -4,6 +4,7 @@ from happytransformer.happy_text_classification import HappyTextClassification
 from happytransformer.happy_next_sentence import HappyNextSentence
 from happytransformer.happy_token_classification import HappyTokenClassification
 from happytransformer.happy_generation import HappyGeneration, GENSettings
+from happytransformer.happy_generation import TFHappyGeneration, GENSettings
 from happytransformer.happy_text_to_text import HappyTextToText, TTSettings
 
 from happytransformer.gen.default_args import ARGS_GEN_TRAIN, ARGS_GEN_EVAl

--- a/happytransformer/cuda_detect.py
+++ b/happytransformer/cuda_detect.py
@@ -1,4 +1,9 @@
 import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
 
 def detect_cuda_device_number():
     return torch.cuda.current_device() if torch.cuda.is_available() else -1
+
+def detect_tpu_device_number():
+    return xm.xla_device().index if xm.xla_device() else -1

--- a/happytransformer/fine_tuning_util.py
+++ b/happytransformer/fine_tuning_util.py
@@ -1,6 +1,5 @@
 """
 Contains functions that are shared amongst the children of the HappyTrainer class.
-
 Based on
 https://github.com/huggingface/transformers/blob/master/examples/pytorch/language-modeling/run_mlm.py
 and
@@ -119,7 +118,6 @@ def get_tpu_device_list_str_long_short():
     """
     tpu_device_list_str_long_short = xu.get_devices_str(long=True, short=True)
     return tpu_device_list_str_long_short
-"""
 
 
 def preprocess_concatenate(tokenizer, dataset, preprocessing_processes, mlm=True):

--- a/happytransformer/fine_tuning_util.py
+++ b/happytransformer/fine_tuning_util.py
@@ -7,6 +7,120 @@ and
 https://github.com/huggingface/transformers/blob/master/examples/pytorch/language-modeling/run_clm.py
 """
 
+import torch_xla.core.xla_model as xm
+import torch_xla.distributed.parallel_loader as pl
+import torch_xla.distributed.xla_multiprocessing as xmp
+import torch_xla.utils.utils as xu
+
+
+def get_tpu_device():
+    """
+    Returns the TPU device if it exists.
+    :return:
+    """
+    tpu_device = xm.xla_device()
+    return tpu_device
+
+
+def get_tpu_strategy():
+    """
+    Returns the TPU strategy if it exists.
+    :return:
+    """
+    tpu_strategy = xm.xla_distributed_strategy()
+    return tpu_strategy
+
+
+def get_tpu_parallel_loader():
+    """
+    Returns the TPU parallel loader if it exists.
+    :return:
+    """
+    tpu_parallel_loader = pl.ParallelLoader(xm.xla_distributed_strategy(), [])
+    return tpu_parallel_loader
+
+
+def get_tpu_multiprocessing():
+    """
+    Returns the TPU multiprocessing if it exists.
+    :return:
+    """
+    tpu_multiprocessing = xmp.spawn(get_tpu_device(), get_tpu_strategy(), get_tpu_parallel_loader())
+    return tpu_multiprocessing
+
+
+def get_tpu_device_ordinal():
+    """
+    Returns the TPU device ordinal if it exists.
+    :return:
+    """
+    tpu_device_ordinal = xm.get_ordinal()
+    return tpu_device_ordinal
+
+
+def get_tpu_device_count():
+    """
+    Returns the TPU device count if it exists.
+    :return:
+    """
+    tpu_device_count = xm.xrt_world_size()
+    return tpu_device_count
+
+
+def get_tpu_device_list():
+    """
+    Returns the TPU device list if it exists.
+    :return:
+    """
+    tpu_device_list = xu.get_devices()
+    return tpu_device_list
+
+
+def get_tpu_device_list_str():
+    """
+    Returns the TPU device list as a string if it exists.
+    :return:
+    """
+    tpu_device_list_str = xu.get_devices_str()
+    return tpu_device_list_str
+
+
+def get_tpu_device_list_str_short():
+    """
+    Returns the TPU device list as a short string if it exists.
+    :return:
+    """
+    tpu_device_list_str_short = xu.get_devices_str(short=True)
+    return tpu_device_list_str_short
+
+
+def get_tpu_device_list_str_long():
+    """
+    Returns the TPU device list as a long string if it exists.
+    :return:
+    """
+    tpu_device_list_str_long = xu.get_devices_str(long=True)
+    return tpu_device_list_str_long
+
+
+def get_tpu_device_list_str_short_long():
+    """
+    Returns the TPU device list as a short and long string if it exists.
+    :return:
+    """
+    tpu_device_list_str_short_long = xu.get_devices_str(short=True, long=True)
+    return tpu_device_list_str_short_long
+
+
+def get_tpu_device_list_str_long_short():
+    """
+    Returns the TPU device list as a long and short string if it exists.
+    :return:
+    """
+    tpu_device_list_str_long_short = xu.get_devices_str(long=True, short=True)
+    return tpu_device_list_str_long_short
+"""
+
 
 def preprocess_concatenate(tokenizer, dataset, preprocessing_processes, mlm=True):
     """

--- a/happytransformer/happy_generation.py
+++ b/happytransformer/happy_generation.py
@@ -4,7 +4,7 @@ Contains the HappyGeneration class
 from dataclasses import dataclass
 from typing import List
 from transformers import TFAutoModelForCausalLM, AutoModelForCausalLM, TextGenerationPipeline
-from happytransformer.happy_transformer import TFHappyTransformer
+from happytransformer.happy_transformer import HappyTransformer, TFHappyTransformer
 from happytransformer.gen.trainer import GENTrainer, GENTrainArgs, GENEvalArgs
 from happytransformer.adaptors import get_adaptor
 from happytransformer.gen import ARGS_GEN_TRAIN, ARGS_GEN_EVAl, ARGS_GEN_TEST
@@ -153,7 +153,7 @@ class HappyGeneration(HappyTransformer):
     def test(self, input_filepath, args=ARGS_GEN_TEST):
         raise NotImplementedError("test() is currently not available")
         
-class TFHappyGeneration(HappyTransformer):
+class TFHappyGeneration(TFHappyTransformer):
     """
     This class is a user facing class that allows users to generate text using
     text generation Transformer models.

--- a/happytransformer/happy_generation.py
+++ b/happytransformer/happy_generation.py
@@ -4,7 +4,7 @@ Contains the HappyGeneration class
 from dataclasses import dataclass
 from typing import List
 from transformers import TFAutoModelForCausalLM, AutoModelForCausalLM, TextGenerationPipeline
-from happytransformer.happy_transformer import HappyTransformer
+from happytransformer.happy_transformer import TFHappyTransformer
 from happytransformer.gen.trainer import GENTrainer, GENTrainArgs, GENEvalArgs
 from happytransformer.adaptors import get_adaptor
 from happytransformer.gen import ARGS_GEN_TRAIN, ARGS_GEN_EVAl, ARGS_GEN_TEST

--- a/happytransformer/happy_generation.py
+++ b/happytransformer/happy_generation.py
@@ -3,7 +3,7 @@ Contains the HappyGeneration class
 """
 from dataclasses import dataclass
 from typing import List
-from transformers import AutoModelForCausalLM, TextGenerationPipeline
+from transformers import TFAutoModelForCausalLM, AutoModelForCausalLM, TextGenerationPipeline
 from happytransformer.happy_transformer import HappyTransformer
 from happytransformer.gen.trainer import GENTrainer, GENTrainArgs, GENEvalArgs
 from happytransformer.adaptors import get_adaptor
@@ -53,6 +53,124 @@ class HappyGeneration(HappyTransformer):
             model = AutoModelForCausalLM.from_pretrained(load_path)
         else:
             model = AutoModelForCausalLM.from_pretrained(model_name, use_auth_token=use_auth_token)
+
+        super().__init__(model_type, model_name, model, use_auth_token=use_auth_token, load_path=load_path)
+        device_number = detect_cuda_device_number()
+
+        self._pipeline = TextGenerationPipeline(model=self.model, tokenizer=self.tokenizer, device=device_number)
+
+        self._trainer = GENTrainer(self.model, model_type, self.tokenizer, self._device, self.logger)
+
+    def __assert_default_text_is_val(self, text):
+        """
+        Ensures the input's text input is valid.
+        Raises a Value Error if the text input is not valid.
+        :param text: The value the user inputs for the "text" parameter
+        """
+
+        if not isinstance(text, str):
+            raise ValueError("The text input must be a string")
+        if not text:
+            raise ValueError("The text input must have at least one character")
+
+
+    def generate_text(self, text: str, args: GENSettings=GENSettings()) -> GenerationResult:
+        """
+        :param text: starting text that the model uses as a prompt to continue it.
+        :param args: A GENSettings object
+        :return: A GenerationResult() object
+        """
+
+        self.__assert_default_text_is_val(text)
+        input_ids = self.tokenizer.encode(text, return_tensors="pt")
+        adjusted_min_length = args.min_length + len(input_ids[0])
+        adjusted_max_length = args.max_length + len(input_ids[0])
+        if args.bad_words:
+            bad_words_ids = [self.tokenizer(" "+phrase.strip()).input_ids for phrase in args.bad_words]
+        else:
+            bad_words_ids = None
+        output = self._pipeline(text, min_length=adjusted_min_length,
+                                return_full_text=False,
+                                max_length=adjusted_max_length,
+                                do_sample=args.do_sample,
+                                early_stopping=args.early_stopping,
+                                num_beams=args.num_beams,
+                                temperature=args.temperature,
+                                top_k=args.top_k,
+                                no_repeat_ngram_size=args.no_repeat_ngram_size,
+                                top_p=args.top_p,
+                                bad_words_ids=bad_words_ids
+                                )
+        return GenerationResult(text=output[0]['generated_text'])
+
+
+    def __post_process_generated_text(self, result, text):
+        """
+        A method for processing the output of the model. More features will be added later.
+        :param result: result the output of the model after being decoded
+        :param text:  the original input to generate_text
+        :return: returns to text after going through post-processing. Removes starting text
+        """
+
+        return result[len(text):]
+
+
+    def train(self, input_filepath: str, args=GENTrainArgs()):
+        """
+        :param input_filepath:a file path to a text file that contains nothing but training data
+        :param args: either a GENTrainArgs() object or a dictionary that contains all of the same keys as ARGS_GEN_TRAIN
+        :return: None
+        """
+
+        if type(args) == dict:
+            method_dataclass_args = create_args_dataclass(default_dic_args=ARGS_GEN_TRAIN,
+                                                         input_dic_args=args,
+                                                         method_dataclass_args=GENTrainArgs)
+        elif type(args) == GENTrainArgs:
+            method_dataclass_args = args
+        else:
+            raise ValueError("Invalid args type. Use a GENTrainArgs object or a dictionary")
+
+        self._trainer.train(input_filepath=input_filepath, dataclass_args=method_dataclass_args)
+
+    def eval(self, input_filepath: str, args=GENEvalArgs()) -> EvalResult:
+        """
+        :param input_filepath:a file path to a text file that contains nothing but evaluating data
+        :param args: either a GENEvalArgs() object or a dictionary that contains all of the same keys as ARGS_GEN_EVAl
+        :return: None
+        """
+        if type(args) == dict:
+            method_dataclass_args = create_args_dataclass(default_dic_args=ARGS_GEN_EVAl,
+                                                         input_dic_args=args,
+                                                         method_dataclass_args=GENEvalArgs)
+        elif type(args) == GENEvalArgs:
+            method_dataclass_args = args
+        else:
+            raise ValueError("Invalid args type. Use a GENEvalArgs object or a dictionary")
+
+        return self._trainer.eval(input_filepath=input_filepath, dataclass_args=method_dataclass_args)
+
+    def test(self, input_filepath, args=ARGS_GEN_TEST):
+        raise NotImplementedError("test() is currently not available")
+        
+class TFHappyGeneration(HappyTransformer):
+    """
+    This class is a user facing class that allows users to generate text using
+    text generation Transformer models.
+
+    The purpose of this class is to be lightweight and easy
+    to understand and to offload complex tasks to
+    other classes.
+    """
+    def __init__(self, model_type: str = "GPT2", model_name: str = "gpt2", 
+                 load_path: str = "", use_auth_token: str = None):
+
+        self.adaptor = get_adaptor(model_type)
+
+        if load_path != "":
+            model = TFAutoModelForCausalLM.from_pretrained(load_path)
+        else:
+            model = TFAutoModelForCausalLM.from_pretrained(model_name, use_auth_token=use_auth_token)
 
         super().__init__(model_type, model_name, model, use_auth_token=use_auth_token, load_path=load_path)
         device_number = detect_cuda_device_number()

--- a/happytransformer/happy_text_to_text.py
+++ b/happytransformer/happy_text_to_text.py
@@ -47,8 +47,10 @@ class HappyTextToText(HappyTransformer):
 
         if load_path != "":
             model = AutoModelForSeq2SeqLM.from_pretrained(load_path)
+            model.gradient_checkpointing_enable()
         else:
             model = AutoModelForSeq2SeqLM.from_pretrained(model_name, use_auth_token=use_auth_token)
+            model.gradient_checkpointing_enable()
 
 
         super().__init__(model_type, model_name, model, use_auth_token=use_auth_token, load_path=load_path)

--- a/happytransformer/happy_text_to_text.py
+++ b/happytransformer/happy_text_to_text.py
@@ -7,7 +7,7 @@ from transformers import Text2TextGenerationPipeline, AutoModelForSeq2SeqLM
 
 from happytransformer.happy_transformer import HappyTransformer
 from happytransformer.tt.trainer import TTTrainer
-from happytransformer.cuda_detect import detect_cuda_device_number
+from happytransformer.cuda_detect import detect_cuda_device_number, detect_tpu_device_number
 from happytransformer.adaptors import get_adaptor
 from happytransformer.tt.trainer import TTTrainArgs, TTEvalArgs, TTTestArgs
 
@@ -24,7 +24,6 @@ class TTSettings:
     """
     Used to adjust the text generation algorithm that's used when
     HappyTextToText.generate() is called 
-
     """
     min_length: int = 10
     max_length: int = 50
@@ -55,7 +54,7 @@ class HappyTextToText(HappyTransformer):
 
         super().__init__(model_type, model_name, model, use_auth_token=use_auth_token, load_path=load_path)
 
-        device_number = detect_cuda_device_number()
+        device_number = detect_tpu_device_number()
 
         self._pipeline = Text2TextGenerationPipeline(model=self.model,
                                                      tokenizer=self.tokenizer, device=device_number)
@@ -110,10 +109,8 @@ class HappyTextToText(HappyTransformer):
     def eval(self, input_filepath, args=TTEvalArgs()):
         """
         Evaluated the text-to-text model
-
         input_filepath: a string that contains the location of a csv file
         for training. Contains the following header values: text_1, text_2
-
         args: A TTEvalArgs() object
         return: an EvalResult() object
         """

--- a/happytransformer/happy_trainer.py
+++ b/happytransformer/happy_trainer.py
@@ -20,7 +20,6 @@ class HappyTrainer:
 
     def train(self, input_filepath, args):
         """
-
         :param input_filepath: A string to file location
         :param args: a dictionary that contains settings
         :return:
@@ -29,7 +28,6 @@ class HappyTrainer:
 
     def test(self, input_filepath, solve, args):
         """
-
         :param input_filepath: A string to file location
         :param solve: a method for using the model for the given task
         :return: test results
@@ -48,7 +46,6 @@ class HappyTrainer:
     @staticmethod
     def _get_data(filepath, test_data=False):
         """
-
         :param filepath:  A string to file location
         :param test_data: False for train and eval, True for test
         :return: varies for each task
@@ -61,9 +58,9 @@ class HappyTrainer:
         :param output_path: A string to a temporary directory
         :return: A TrainingArguments object
         """
-        if self.device != "cuda":
+        if self.device != "cuda" and self.device != "xla":
             if dataclass_args.fp16:
-                ValueError("fp16 is only available when CUDA/ a GPU is being used. ")
+                ValueError("fp16 is only available when CUDA/ a GPU or XLA is being used. ")
 
         return TrainingArguments(
             output_dir=output_path,
@@ -84,7 +81,6 @@ class HappyTrainer:
 
     def _run_train(self, dataset, dataclass_args, data_collator):
         """
-
         :param dataset: a child of torch.utils.data.Dataset
         :param dataclass_args: a dataclass that contains settings
         :return: None

--- a/happytransformer/happy_transformer.py
+++ b/happytransformer/happy_transformer.py
@@ -92,3 +92,86 @@ class HappyTransformer():
         self.model.save_pretrained(path)
         self.tokenizer.save_pretrained(path)
 
+class TFHappyTransformer():
+    """
+    Parent class to HappyTextClassification, HappyWordPrediction, HappyQuestionAnswering
+    and HappyNextSentencePrediction.
+
+    """
+
+    def __init__(self, model_type, model_name, model, load_path="", use_auth_token: str = None):
+        self.model_type = model_type  # BERT, #DISTILBERT, ROBERTA, ALBERT etc
+        self.model_name = model_name
+
+        if load_path != "":
+            self.tokenizer = AutoTokenizer.from_pretrained(load_path)
+        else:
+            self.tokenizer = AutoTokenizer.from_pretrained(model_name, use_auth_token=use_auth_token)
+        self.model = model
+#        self.model.eval()
+        self._trainer = None  # initialized in child class
+
+        # todo  change logging system
+        self.logger = logging.getLogger(__name__)
+
+        handler = logging.StreamHandler()
+        handler.addFilter(logging.Filter('happytransformer'))
+        logging.basicConfig(
+            format='%(asctime)s - %(levelname)s - %(name)s -   %(message)s',
+            datefmt='%m/%d/%Y %H:%M:%S',
+            level=logging.INFO,
+            handlers=[handler]
+        )
+
+        self._device = torch.device(
+            "cuda" if torch.cuda.is_available()
+            else "cpu"
+        )
+
+        if self._device == 'cuda':
+            self.model.to(self._device)
+        self.logger.info("Using model: %s", self._device)
+
+
+    def train(self, input_filepath, args):
+        """
+        Trains a model
+        :param input_filepath: a string that contains a path to a csv file
+         that contains testing data
+        :param args: settings in the form of a dictionary
+        :return: None
+        """
+        raise NotImplementedError()
+
+    def eval(self, input_filepath, args):
+        """
+        Evaluates the model. Determines how well the model performs on a given dataset
+        :param input_filepath: a string that contains a path to a
+         csv file that contains evaluating data
+        :param args: settings in the form of a dictionary
+        :return: correct percentage
+        """
+        raise NotImplementedError()
+
+    def test(self, input_filepath, args):
+        """
+        Used to generate predictions for a given dataset.
+        The dataset may not be labelled.
+        :param args: settings in the form of a dictionary
+
+        :param input_filepath: a string that contains a path to
+        a csv file that contains testing data
+
+        """
+        raise NotImplementedError()
+
+    def save(self, path):
+        """
+        Saves both the model, tokenizer and various configuration/settings files
+        to a given path
+
+        :param path: string:  a path to a directory
+        :return:
+        """
+        self.model.save_pretrained(path)
+        self.tokenizer.save_pretrained(path)

--- a/happytransformer/happy_transformer.py
+++ b/happytransformer/happy_transformer.py
@@ -1,7 +1,6 @@
 """
 Contains the parent class to HappyTextClassification, HappyWordPrediction, HappyQuestionAnswering
 and HappyNextSentencePrediction called HappyTransformer
-
 Contains shared variables and methods for these classes.
 """
 import logging
@@ -12,7 +11,6 @@ class HappyTransformer():
     """
     Parent class to HappyTextClassification, HappyWordPrediction, HappyQuestionAnswering
     and HappyNextSentencePrediction.
-
     """
 
     def __init__(self, model_type, model_name, model, load_path="", use_auth_token: str = None):
@@ -40,8 +38,8 @@ class HappyTransformer():
         )
 
         self._device = torch.device(
-            "cuda" if torch.cuda.is_available()
-            else "cpu"
+            "xla" if torch.cuda.is_available()
+            else "xla"
         )
 
         if self._device == 'cuda':
@@ -74,10 +72,8 @@ class HappyTransformer():
         Used to generate predictions for a given dataset.
         The dataset may not be labelled.
         :param args: settings in the form of a dictionary
-
         :param input_filepath: a string that contains a path to
         a csv file that contains testing data
-
         """
         raise NotImplementedError()
 
@@ -85,91 +81,6 @@ class HappyTransformer():
         """
         Saves both the model, tokenizer and various configuration/settings files
         to a given path
-
-        :param path: string:  a path to a directory
-        :return:
-        """
-        self.model.save_pretrained(path)
-        self.tokenizer.save_pretrained(path)
-
-class TFHappyTransformer():
-    """
-    Parent class to HappyTextClassification, HappyWordPrediction, HappyQuestionAnswering
-    and HappyNextSentencePrediction.
-
-    """
-
-    def __init__(self, model_type, model_name, model, load_path="", use_auth_token: str = None):
-        self.model_type = model_type  # BERT, #DISTILBERT, ROBERTA, ALBERT etc
-        self.model_name = model_name
-
-        if load_path != "":
-            self.tokenizer = AutoTokenizer.from_pretrained(load_path)
-        else:
-            self.tokenizer = AutoTokenizer.from_pretrained(model_name, use_auth_token=use_auth_token)
-        self.model = model
-#        self.model.eval()
-        self._trainer = None  # initialized in child class
-
-        # todo  change logging system
-        self.logger = logging.getLogger(__name__)
-
-        handler = logging.StreamHandler()
-        handler.addFilter(logging.Filter('happytransformer'))
-        logging.basicConfig(
-            format='%(asctime)s - %(levelname)s - %(name)s -   %(message)s',
-            datefmt='%m/%d/%Y %H:%M:%S',
-            level=logging.INFO,
-            handlers=[handler]
-        )
-
-        self._device = torch.device(
-            "cuda" if torch.cuda.is_available()
-            else "cpu"
-        )
-
-        if self._device == 'cuda':
-            self.model.to(self._device)
-        self.logger.info("Using model: %s", self._device)
-
-
-    def train(self, input_filepath, args):
-        """
-        Trains a model
-        :param input_filepath: a string that contains a path to a csv file
-         that contains testing data
-        :param args: settings in the form of a dictionary
-        :return: None
-        """
-        raise NotImplementedError()
-
-    def eval(self, input_filepath, args):
-        """
-        Evaluates the model. Determines how well the model performs on a given dataset
-        :param input_filepath: a string that contains a path to a
-         csv file that contains evaluating data
-        :param args: settings in the form of a dictionary
-        :return: correct percentage
-        """
-        raise NotImplementedError()
-
-    def test(self, input_filepath, args):
-        """
-        Used to generate predictions for a given dataset.
-        The dataset may not be labelled.
-        :param args: settings in the form of a dictionary
-
-        :param input_filepath: a string that contains a path to
-        a csv file that contains testing data
-
-        """
-        raise NotImplementedError()
-
-    def save(self, path):
-        """
-        Saves both the model, tokenizer and various configuration/settings files
-        to a given path
-
         :param path: string:  a path to a directory
         :return:
         """

--- a/happytransformer/tt/trainer.py
+++ b/happytransformer/tt/trainer.py
@@ -1,6 +1,5 @@
 """
 Fine-tune Text-to-text models
-
 Based on the following sources:
 1. https://github.com/huggingface/notebooks/blob/master/examples/summarization.ipynb
 2. https://github.com/huggingface/transformers/blob/master/examples/pytorch/summarization/run_summarization.py
@@ -13,6 +12,7 @@ from dataclasses import dataclass
 from happytransformer.happy_trainer import HappyTrainer, EvalResult
 from datasets import load_dataset
 from transformers import DataCollatorForSeq2Seq, Seq2SeqTrainingArguments, Seq2SeqTrainer
+import torch_xla.core.xla_model as xm
 import tempfile
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=1.0
+torch==1.9
 tqdm>=4.43
 transformers>=4.4.0
 pytest
@@ -6,4 +6,3 @@ datasets>=1.6.0
 dataclasses; python_version<"3.7"
 sentencepiece
 protobuf
-torch_xla

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch==1.9
+torch==1.10, !torch-1.11
 tqdm>=4.43
 transformers>=4.4.0
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ datasets>=1.6.0
 dataclasses; python_version<"3.7"
 sentencepiece
 protobuf
+torch_xla


### PR DESCRIPTION
Added preliminary TensorFlow (and MacBook M1 GPU) support for text generation by creating two new classes: TFHappyTransformer and TFHappyGeneration. However, since I created two full new classes by copying and slightly modifying each, I'm guessing this isn't the most efficient for updating in the future. Though, it technically works.

To use TensorFlow models, simply replace HappyGeneration with TFHappyGeneration. Everything else stays the same.

Currently, only generation works. Fine-tuning does not.

I've tested adding TensorFlow support for text2text, and it worked well. However, that is not added to my repository yet.

In order to get the models to load correctly, I had to remove eval() from TFHappyTransformer. I'm not sure why, so this needs to be looked into.