### PR TITLE
Fix removed newline for text generation training 

### DIFF
--- a/happytransformer/fine_tuning_util.py
+++ b/happytransformer/fine_tuning_util.py
@@ -22,7 +22,10 @@ def preprocess_concatenate(tokenizer, dataset, preprocessing_processes, mlm=True
 
 
     def tokenize_function(example):
-        return tokenizer(example["text"])
+        texts = example["text"]
+        # Add newlines back that were removed from load_dataset().
+        texts = [case + "\n" for case in texts[:]]
+        return tokenizer(texts)
 
     tokenized_dataset = dataset.map(tokenize_function, batched=True,
                                       num_proc=preprocessing_processes,

--- a/happytransformer/gen/trainer.py
+++ b/happytransformer/gen/trainer.py
@@ -57,6 +57,7 @@ class GENTrainer(HappyTrainer):
 
         if not dataclass_args.load_preprocessed_data:
             self.logger.info("Preprocessing dataset...")
+            # load_dataset separates the next by newline. Newlines are added back within preprocess_concatenate.
             dataset = load_dataset("text", data_files={"train": input_filepath})
             tokenized_dataset = preprocess_concatenate(self.tokenizer, dataset, dataclass_args.preprocessing_processes, False)
 

--- a/tests/test_tt.py
+++ b/tests/test_tt.py
@@ -98,11 +98,11 @@ def test_tt_eval_loss_decreases():
 
 def test_tt_train_custom_p():
     happy_tt = HappyTextToText("T5", "t5-small")
-    args = TTTrainArgs(num_train_epochs=2, max_input_length=100, max_output_length=100, preprocessing_processes=4, batch_size=2)
+    args = TTTrainArgs(num_train_epochs=2, max_input_length=100, max_output_length=100, preprocessing_processes=1, batch_size=2)
     happy_tt.train("../data/tt/train-eval-grammar.csv", args=args)
 
 def test_tt_eval_custom_p():
     happy_tt = HappyTextToText("T5", "t5-small")
-    args = TTEvalArgs(max_input_length=100, max_output_length=100, preprocessing_processes=4, batch_size=2)
+    args = TTEvalArgs(max_input_length=100, max_output_length=100, preprocessing_processes=1, batch_size=2)
     result = happy_tt.eval("../data/tt/train-eval-grammar.csv", args=args)
     assert type(result.loss) is float


### PR DESCRIPTION
Closes #283 

Hugging Face's load_dataset() function separates by newline by default and removes the newlines. Now, newlines are added back within  the preprocess_concatenate() function. 